### PR TITLE
Add support for adding a user agent header to the request

### DIFF
--- a/RestAssured.Net.Tests/UserAgentTests.cs
+++ b/RestAssured.Net.Tests/UserAgentTests.cs
@@ -1,0 +1,109 @@
+// <copyright file="UserAgentTests.cs" company="On Test Automation">
+// Copyright 2019 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+using System.Net.Http.Headers;
+using NUnit.Framework;
+using RestAssured.Net.RA.Builders;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using static RestAssuredNet.RestAssuredNet;
+
+namespace RestAssuredNet.Tests
+{
+    /// <summary>
+    /// Examples of RestAssuredNet usage.
+    /// </summary>
+    [TestFixture]
+    public class UserAgentTests : TestBase
+    {
+        private RequestSpecification? requestSpecification;
+
+        /// <summary>
+        /// Creates the <see cref="RequestSpecification"/> instances to be used in the tests in this class.
+        /// </summary>
+        [SetUp]
+        public void CreateRequestSpecifications()
+        {
+            this.requestSpecification = new RequestSpecBuilder()
+                .WithScheme("http")
+                .WithHostName("localhost")
+                .WithPort(9876)
+                .WithUserAgent(new ProductInfoHeaderValue("MyUserAgent", "1.0"))
+                .Build();
+        }
+
+        /// <summary>
+        /// A test demonstrating RestAssuredNet syntax for specifying
+        /// a user agent for a specific request when sending an HTTP request.
+        /// </summary>
+        [Test]
+        public void CustomUserAgentCanBeSuppliedUsingProductInfoHeaderValueInTest()
+        {
+            this.CreateStubForUserAgent();
+
+            Given()
+            .UserAgent(new ProductInfoHeaderValue("MyUserAgent", "1.0"))
+            .When()
+            .Get("http://localhost:9876/user-agent")
+            .Then()
+            .StatusCode(200);
+        }
+
+        /// <summary>
+        /// A test demonstrating RestAssuredNet syntax for specifying
+        /// a user agent for a specific request when sending an HTTP request.
+        /// </summary>
+        [Test]
+        public void CustomUserAgentCanBeSuppliedUsingProductNameAndProductVersionInTest()
+        {
+            this.CreateStubForUserAgent();
+
+            Given()
+            .UserAgent("MyUserAgent", "1.0")
+            .When()
+            .Get("http://localhost:9876/user-agent")
+            .Then()
+            .StatusCode(200);
+        }
+
+        /// <summary>
+        /// A test demonstrating RestAssuredNet syntax for specifying
+        /// a user agent using a request specification.
+        /// </summary>
+        [Test]
+        public void CustomUserAgentCanBeSuppliedThroughRequestSpecification()
+        {
+            this.CreateStubForUserAgent();
+
+            Given()
+            .Spec(this.requestSpecification)
+            .When()
+            .Get("/user-agent")
+            .Then()
+            .StatusCode(200);
+        }
+
+        /// <summary>
+        /// Creates the stub response for the form data example.
+        /// </summary>
+        private void CreateStubForUserAgent()
+        {
+            this.Server.Given(Request.Create().WithPath("/user-agent").UsingGet()
+                .WithHeader("User-Agent", "MyUserAgent/1.0"))
+                .RespondWith(Response.Create()
+                .WithStatusCode(200));
+        }
+    }
+}

--- a/RestAssured.Net/RA/Builders/RequestSpecBuilder.cs
+++ b/RestAssured.Net/RA/Builders/RequestSpecBuilder.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 using System;
+using System.Net.Http.Headers;
 
 namespace RestAssured.Net.RA.Builders
 {
@@ -29,13 +30,14 @@ namespace RestAssured.Net.RA.Builders
         private readonly int port = 80;
         private readonly string basePath = string.Empty;
         private readonly TimeSpan? timeout;
+        private readonly ProductInfoHeaderValue? userAgent;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RequestSpecBuilder"/> class.
         /// </summary>
         public RequestSpecBuilder()
         {
-            this.requestSpecification = new RequestSpecification(this.scheme, this.host, this.port, this.basePath, this.timeout);
+            this.requestSpecification = new RequestSpecification(this.scheme, this.host, this.port, this.basePath, this.timeout, this.userAgent);
         }
 
         /// <summary>
@@ -90,6 +92,29 @@ namespace RestAssured.Net.RA.Builders
         public RequestSpecBuilder WithTimeout(TimeSpan timeout)
         {
             this.requestSpecification.Timeout = timeout;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the user agent on the <see cref="RequestSpecification"/> to build.
+        /// </summary>
+        /// <param name="userAgent">The user agent to use for the requests.</param>
+        /// <returns>The current <see cref="RequestSpecBuilder"/> object.</returns>
+        public RequestSpecBuilder WithUserAgent(ProductInfoHeaderValue userAgent)
+        {
+            this.requestSpecification.UserAgent = userAgent;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the user agent on the <see cref="RequestSpecification"/> to build.
+        /// </summary>
+        /// <param name="productName">The user agent product name to use for the requests.</param>
+        /// <param name="productVersion">The user agent product version to use for the requests.</param>
+        /// <returns>The current <see cref="RequestSpecBuilder"/> object.</returns>
+        public RequestSpecBuilder WithUserAgent(string productName, string productVersion)
+        {
+            this.requestSpecification.UserAgent = new ProductInfoHeaderValue(productName, productVersion);
             return this;
         }
 

--- a/RestAssured.Net/RA/Builders/RequestSpecification.cs
+++ b/RestAssured.Net/RA/Builders/RequestSpecification.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 using System;
+using System.Net.Http.Headers;
 
 namespace RestAssured.Net.RA.Builders
 {
@@ -48,6 +49,11 @@ namespace RestAssured.Net.RA.Builders
         public TimeSpan? Timeout { get; set; }
 
         /// <summary>
+        /// The user agent to be used when sending the request.
+        /// </summary>
+        public ProductInfoHeaderValue? UserAgent { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="RequestSpecification"/> class.
         /// </summary>
         /// <param name="scheme">The scheme (http, https, ....) to use in this request.</param>
@@ -55,13 +61,15 @@ namespace RestAssured.Net.RA.Builders
         /// <param name="port">The port number to use in this request.</param>
         /// <param name="basePath">The base path to use in this request.</param>
         /// <param name="timeout">The timeout to use for this request.</param>
-        public RequestSpecification(string scheme, string host, int port, string basePath, TimeSpan? timeout)
+        /// <param name="userAgent">The user agent to use for this request.</param>
+        public RequestSpecification(string scheme, string host, int port, string basePath, TimeSpan? timeout, ProductInfoHeaderValue? userAgent)
         {
             this.Scheme = scheme;
             this.HostName = host;
             this.Port = port;
             this.BasePath = basePath;
             this.Timeout = timeout;
+            this.UserAgent = userAgent;
         }
     }
 }

--- a/RestAssured.Net/RA/ExecutableRequest.cs
+++ b/RestAssured.Net/RA/ExecutableRequest.cs
@@ -253,6 +253,29 @@ namespace RestAssuredNet.RA
         }
 
         /// <summary>
+        /// User to set a custom User Agent value for the request.
+        /// </summary>
+        /// <param name="product">The <see cref="ProductInfoHeaderValue"/> for the user agent to add to the request.</param>
+        /// <returns>The current <see cref="ExecutableRequest"/> object.</returns>
+        public ExecutableRequest UserAgent(ProductInfoHeaderValue product)
+        {
+            this.request.Headers.UserAgent.Add(product);
+            return this;
+        }
+
+        /// <summary>
+        /// User to set a custom User Agent value for the request.
+        /// </summary>
+        /// <param name="productName">The value for the user agent product name to add to the request.</param>
+        /// <param name="productVersion">the value for the user agent product version to add to the request.</param>
+        /// <returns>The current <see cref="ExecutableRequest"/> object.</returns>
+        public ExecutableRequest UserAgent(string productName, string productVersion)
+        {
+            this.UserAgent(new ProductInfoHeaderValue(productName, productVersion));
+            return this;
+        }
+
+        /// <summary>
         /// Adds a request body to the request object to be sent.
         /// </summary>
         /// <param name="body">The body that is to be sent with the request.</param>

--- a/RestAssured.Net/RA/Internal/RequestSpecificationProcessor.cs
+++ b/RestAssured.Net/RA/Internal/RequestSpecificationProcessor.cs
@@ -59,6 +59,11 @@ namespace RestAssured.Net.RA.Internal
                 }
             }
 
+            if (requestSpec.UserAgent != null)
+            {
+                request.Headers.UserAgent.Add(requestSpec.UserAgent);
+            }
+
             return request;
         }
 


### PR DESCRIPTION
This PR adds the capability to add user agent details, both for individual requests as well as using a RequestSpecification.