### PR TITLE
Feature/headers in requestspec

### DIFF
--- a/RestAssured.Net.Tests/RequestSpecificationTests.cs
+++ b/RestAssured.Net.Tests/RequestSpecificationTests.cs
@@ -15,6 +15,7 @@
 // </copyright>
 using NUnit.Framework;
 using RestAssured.Net.RA.Builders;
+using WireMock.Matchers;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using static RestAssuredNet.RestAssuredNet;
@@ -30,6 +31,7 @@ namespace RestAssuredNet.Tests
         private RequestSpecification? fullRequestSpecification;
         private RequestSpecification? applyDefaultsRequestSpecification;
         private RequestSpecification? incorrectHostNameSpecification;
+        private RequestSpecification? headersSpecification;
 
         /// <summary>
         /// Creates the <see cref="RequestSpecification"/> instances to be used in the tests in this class.
@@ -51,6 +53,13 @@ namespace RestAssuredNet.Tests
             this.incorrectHostNameSpecification = new RequestSpecBuilder()
                 .WithHostName("http://localhost")
                 .WithPort(9876)
+                .Build();
+
+            this.headersSpecification = new RequestSpecBuilder()
+                .WithScheme("http")
+                .WithHostName("localhost")
+                .WithPort(9876)
+                .WithHeader("custom_header", "custom_header_value")
                 .Build();
         }
 
@@ -93,6 +102,24 @@ namespace RestAssuredNet.Tests
         }
 
         /// <summary>
+        /// A test demonstrating RestAssuredNet syntax for including
+        /// a request specification with headers added.
+        /// </summary>
+        [Test]
+        public void RequestSpecificationWithHeadersCanBeUsed()
+        {
+            this.CreateStubForRequestSpecificationWithHeaders();
+
+            Given()
+            .Spec(this.headersSpecification)
+            .Header("another_header", "another_header_value")
+            .When()
+            .Get("/request-specification-with-headers")
+            .Then()
+            .StatusCode(200);
+        }
+
+        /// <summary>
         /// A test demonstrating RestAssuredNet syntax showing that
         /// using a hostname in the request specification including the scheme
         /// throws the expected exception.
@@ -121,6 +148,18 @@ namespace RestAssuredNet.Tests
         private void CreateStubForRequestSpecification()
         {
             this.Server.Given(Request.Create().WithPath("/api/request-specification").UsingGet())
+                .RespondWith(Response.Create()
+                .WithStatusCode(200));
+        }
+
+        /// <summary>
+        /// Creates the stub response for the example setting the accept header as a string.
+        /// </summary>
+        private void CreateStubForRequestSpecificationWithHeaders()
+        {
+            this.Server.Given(Request.Create().WithPath("/request-specification-with-headers").UsingGet()
+                .WithHeader("custom_header", "custom_header_value")
+                .WithHeader("another_header", "another_header_value"))
                 .RespondWith(Response.Create()
                 .WithStatusCode(200));
         }

--- a/RestAssured.Net.Tests/RequestSpecificationTests.cs
+++ b/RestAssured.Net.Tests/RequestSpecificationTests.cs
@@ -32,6 +32,7 @@ namespace RestAssuredNet.Tests
         private RequestSpecification? applyDefaultsRequestSpecification;
         private RequestSpecification? incorrectHostNameSpecification;
         private RequestSpecification? headersSpecification;
+        private RequestSpecification? oauthSpecification;
 
         /// <summary>
         /// Creates the <see cref="RequestSpecification"/> instances to be used in the tests in this class.
@@ -59,7 +60,15 @@ namespace RestAssuredNet.Tests
                 .WithScheme("http")
                 .WithHostName("localhost")
                 .WithPort(9876)
+                .WithBasicAuth("username", "password")
                 .WithHeader("custom_header", "custom_header_value")
+                .Build();
+
+            this.oauthSpecification = new RequestSpecBuilder()
+                .WithScheme("http")
+                .WithHostName("localhost")
+                .WithPort(9876)
+                .WithOAuth2("this_is_my_token")
                 .Build();
         }
 
@@ -120,6 +129,23 @@ namespace RestAssuredNet.Tests
         }
 
         /// <summary>
+        /// A test demonstrating RestAssuredNet syntax for including
+        /// a request specification with OAuth2 details added.
+        /// </summary>
+        [Test]
+        public void RequestSpecificationWithOAuth2CanBeUsed()
+        {
+            this.CreateStubForRequestSpecificationWithOAuth2();
+
+            Given()
+            .Spec(this.oauthSpecification)
+            .When()
+            .Get("/request-specification-with-oauth2")
+            .Then()
+            .StatusCode(200);
+        }
+
+        /// <summary>
         /// A test demonstrating RestAssuredNet syntax showing that
         /// using a hostname in the request specification including the scheme
         /// throws the expected exception.
@@ -143,7 +169,7 @@ namespace RestAssuredNet.Tests
         }
 
         /// <summary>
-        /// Creates the stub response for the example setting the accept header as a string.
+        /// Creates the stub response for the request specification tests.
         /// </summary>
         private void CreateStubForRequestSpecification()
         {
@@ -153,13 +179,25 @@ namespace RestAssuredNet.Tests
         }
 
         /// <summary>
-        /// Creates the stub response for the example setting the accept header as a string.
+        /// Creates the stub response for the request specification with headers tests.
         /// </summary>
         private void CreateStubForRequestSpecificationWithHeaders()
         {
             this.Server.Given(Request.Create().WithPath("/request-specification-with-headers").UsingGet()
+                .WithHeader("Authorization", new ExactMatcher("Basic dXNlcm5hbWU6cGFzc3dvcmQ="))
                 .WithHeader("custom_header", "custom_header_value")
                 .WithHeader("another_header", "another_header_value"))
+                .RespondWith(Response.Create()
+                .WithStatusCode(200));
+        }
+
+        /// <summary>
+        /// Creates the stub response for the request specification with an OAuth2 token tests.
+        /// </summary>
+        private void CreateStubForRequestSpecificationWithOAuth2()
+        {
+            this.Server.Given(Request.Create().WithPath("/request-specification-with-oauth2").UsingGet()
+                .WithHeader("Authorization", new ExactMatcher("Bearer this_is_my_token")))
                 .RespondWith(Response.Create()
                 .WithStatusCode(200));
         }

--- a/RestAssured.Net/RA/Builders/RequestSpecBuilder.cs
+++ b/RestAssured.Net/RA/Builders/RequestSpecBuilder.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http.Headers;
+using System.Text;
 
 namespace RestAssured.Net.RA.Builders
 {
@@ -35,13 +36,14 @@ namespace RestAssured.Net.RA.Builders
         private readonly ProductInfoHeaderValue? userAgent;
         private readonly IWebProxy? proxy;
         private readonly Dictionary<string, object> headers = new Dictionary<string, object>();
+        private readonly AuthenticationHeaderValue? authenticationHeader;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RequestSpecBuilder"/> class.
         /// </summary>
         public RequestSpecBuilder()
         {
-            this.requestSpecification = new RequestSpecification(this.scheme, this.host, this.port, this.basePath, this.timeout, this.userAgent, this.proxy, this.headers);
+            this.requestSpecification = new RequestSpecification(this.scheme, this.host, this.port, this.basePath, this.timeout, this.userAgent, this.proxy, this.headers, this.authenticationHeader);
         }
 
         /// <summary>
@@ -142,6 +144,30 @@ namespace RestAssured.Net.RA.Builders
         public RequestSpecBuilder WithHeader(string key, object value)
         {
             this.requestSpecification.Headers[key] = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a basic authorization header to the request.
+        /// </summary>
+        /// <param name="username">The username to be used for authorization.</param>
+        /// <param name="password">The password to be used for authorization.</param>
+        /// <returns>The current <see cref="RequestSpecBuilder"/> object.</returns>
+        public RequestSpecBuilder WithBasicAuth(string username, string password)
+        {
+            string base64EncodedBasicAuthDetails = Convert.ToBase64String(Encoding.ASCII.GetBytes($"{username}:{password}"));
+            this.requestSpecification.AuthenticationHeader = new AuthenticationHeaderValue("Basic", base64EncodedBasicAuthDetails);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds an OAuth2 authorization header to the request.
+        /// </summary>
+        /// <param name="token">The OAuth2 token to be used for authorization.</param>
+        /// <returns>The current <see cref="RequestSpecBuilder"/> object.</returns>
+        public RequestSpecBuilder WithOAuth2(string token)
+        {
+            this.requestSpecification.AuthenticationHeader = new AuthenticationHeaderValue("Bearer", token);
             return this;
         }
 

--- a/RestAssured.Net/RA/Builders/RequestSpecBuilder.cs
+++ b/RestAssured.Net/RA/Builders/RequestSpecBuilder.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http.Headers;
 
@@ -33,13 +34,14 @@ namespace RestAssured.Net.RA.Builders
         private readonly TimeSpan? timeout;
         private readonly ProductInfoHeaderValue? userAgent;
         private readonly IWebProxy? proxy;
+        private readonly Dictionary<string, object> headers = new Dictionary<string, object>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RequestSpecBuilder"/> class.
         /// </summary>
         public RequestSpecBuilder()
         {
-            this.requestSpecification = new RequestSpecification(this.scheme, this.host, this.port, this.basePath, this.timeout, this.userAgent, this.proxy);
+            this.requestSpecification = new RequestSpecification(this.scheme, this.host, this.port, this.basePath, this.timeout, this.userAgent, this.proxy, this.headers);
         }
 
         /// <summary>
@@ -128,6 +130,18 @@ namespace RestAssured.Net.RA.Builders
         public RequestSpecBuilder WithUserAgent(string productName, string productVersion)
         {
             this.requestSpecification.UserAgent = new ProductInfoHeaderValue(productName, productVersion);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a header on the <see cref="RequestSpecification"/> to build.
+        /// </summary>
+        /// <param name="key">The header name to add.</param>
+        /// <param name="value">The associated header value.</param>
+        /// <returns>The current <see cref="RequestSpecBuilder"/> object.</returns>
+        public RequestSpecBuilder WithHeader(string key, object value)
+        {
+            this.requestSpecification.Headers[key] = value;
             return this;
         }
 

--- a/RestAssured.Net/RA/Builders/RequestSpecification.cs
+++ b/RestAssured.Net/RA/Builders/RequestSpecification.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http.Headers;
 
@@ -60,6 +61,11 @@ namespace RestAssured.Net.RA.Builders
         public IWebProxy? Proxy { get; set; }
 
         /// <summary>
+        /// The headers to be added when sending the request.
+        /// </summary>
+        public Dictionary<string, object> Headers { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="RequestSpecification"/> class.
         /// </summary>
         /// <param name="scheme">The scheme (http, https, ....) to use in this request.</param>
@@ -69,7 +75,8 @@ namespace RestAssured.Net.RA.Builders
         /// <param name="timeout">The timeout to use for this request.</param>
         /// <param name="userAgent">The user agent to use for this request.</param>
         /// <param name="proxy">The proxy to use for this request.</param>
-        public RequestSpecification(string scheme, string host, int port, string basePath, TimeSpan? timeout, ProductInfoHeaderValue? userAgent, IWebProxy proxy)
+        /// <param name="headers">The headers to add to this request.</param>
+        public RequestSpecification(string scheme, string host, int port, string basePath, TimeSpan? timeout, ProductInfoHeaderValue? userAgent, IWebProxy proxy, Dictionary<string, object> headers)
         {
             this.Scheme = scheme;
             this.HostName = host;
@@ -78,6 +85,7 @@ namespace RestAssured.Net.RA.Builders
             this.Timeout = timeout;
             this.UserAgent = userAgent;
             this.Proxy = proxy;
+            this.Headers = headers;
         }
     }
 }

--- a/RestAssured.Net/RA/Builders/RequestSpecification.cs
+++ b/RestAssured.Net/RA/Builders/RequestSpecification.cs
@@ -66,6 +66,11 @@ namespace RestAssured.Net.RA.Builders
         public Dictionary<string, object> Headers { get; set; }
 
         /// <summary>
+        /// Authentication details to be added when sending the request.
+        /// </summary>
+        public AuthenticationHeaderValue AuthenticationHeader { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="RequestSpecification"/> class.
         /// </summary>
         /// <param name="scheme">The scheme (http, https, ....) to use in this request.</param>
@@ -76,7 +81,7 @@ namespace RestAssured.Net.RA.Builders
         /// <param name="userAgent">The user agent to use for this request.</param>
         /// <param name="proxy">The proxy to use for this request.</param>
         /// <param name="headers">The headers to add to this request.</param>
-        public RequestSpecification(string scheme, string host, int port, string basePath, TimeSpan? timeout, ProductInfoHeaderValue? userAgent, IWebProxy proxy, Dictionary<string, object> headers)
+        public RequestSpecification(string scheme, string host, int port, string basePath, TimeSpan? timeout, ProductInfoHeaderValue? userAgent, IWebProxy proxy, Dictionary<string, object> headers, AuthenticationHeaderValue authenticationHeader)
         {
             this.Scheme = scheme;
             this.HostName = host;
@@ -86,6 +91,7 @@ namespace RestAssured.Net.RA.Builders
             this.UserAgent = userAgent;
             this.Proxy = proxy;
             this.Headers = headers;
+            this.AuthenticationHeader = authenticationHeader;
         }
     }
 }

--- a/RestAssured.Net/RA/Internal/RequestSpecificationProcessor.cs
+++ b/RestAssured.Net/RA/Internal/RequestSpecificationProcessor.cs
@@ -70,6 +70,11 @@ namespace RestAssured.Net.RA.Internal
                 request.Headers.UserAgent.Add(requestSpec.UserAgent);
             }
 
+            if (requestSpec.AuthenticationHeader != null)
+            {
+                request.Headers.Authorization = request.Headers.Authorization ?? requestSpec.AuthenticationHeader;
+            }
+
             return request;
         }
 

--- a/RestAssured.Net/RA/Internal/RequestSpecificationProcessor.cs
+++ b/RestAssured.Net/RA/Internal/RequestSpecificationProcessor.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using RestAssured.Net.RA.Builders;
 using RestAssuredNet.RA.Exceptions;
@@ -57,6 +58,11 @@ namespace RestAssured.Net.RA.Internal
                 {
                     throw new RequestCreationException($"Supplied base URI '{requestSpec.Scheme}://{requestSpec.HostName}:{requestSpec.Port}' is invalid.");
                 }
+            }
+
+            foreach (KeyValuePair<string, object> entry in requestSpec.Headers)
+            {
+                request.Headers.Add(entry.Key, entry.Value.ToString());
             }
 
             if (requestSpec.UserAgent != null)


### PR DESCRIPTION
This PR adds the capability to:

* Specify headers in a request specification
* Specify Basic and OAuth2 authorization details in a request specification