### PR TITLE
reafactor: fix usings and namespaces

### DIFF
--- a/RestAssured.Net.Tests/AuthorizationTests.cs
+++ b/RestAssured.Net.Tests/AuthorizationTests.cs
@@ -13,13 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
 using NUnit.Framework;
 using WireMock.Matchers;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using static RestAssuredNet.RestAssuredNet;
 
-namespace RestAssuredNet.Tests
+namespace RestAssured.Net.Tests
 {
     /// <summary>
     /// Examples of RestAssuredNet usage.

--- a/RestAssured.Net.Tests/CookieTests.cs
+++ b/RestAssured.Net.Tests/CookieTests.cs
@@ -13,16 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
-using System.Collections.Generic;
+
 using System.Net;
-using System.Text;
 using NUnit.Framework;
-using WireMock.Matchers;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using static RestAssuredNet.RestAssuredNet;
 
-namespace RestAssuredNet.Tests
+namespace RestAssured.Net.Tests
 {
     /// <summary>
     /// Examples of RestAssuredNet usage.

--- a/RestAssured.Net.Tests/FormDataTests.cs
+++ b/RestAssured.Net.Tests/FormDataTests.cs
@@ -13,16 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
 using System.Collections.Generic;
-using System.Net;
-using System.Text;
 using NUnit.Framework;
 using WireMock.Matchers;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using static RestAssuredNet.RestAssuredNet;
 
-namespace RestAssuredNet.Tests
+namespace RestAssured.Net.Tests
 {
     /// <summary>
     /// Examples of RestAssuredNet usage.

--- a/RestAssured.Net.Tests/HttpVerbTests.cs
+++ b/RestAssured.Net.Tests/HttpVerbTests.cs
@@ -13,12 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
 using NUnit.Framework;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using static RestAssuredNet.RestAssuredNet;
 
-namespace RestAssuredNet.Tests
+namespace RestAssured.Net.Tests
 {
     /// <summary>
     /// Examples of RestAssuredNet usage.

--- a/RestAssured.Net.Tests/HttpsSslTests.cs
+++ b/RestAssured.Net.Tests/HttpsSslTests.cs
@@ -13,13 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
 using NUnit.Framework;
 using RestAssured.Net.RA.Builders;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using static RestAssuredNet.RestAssuredNet;
 
-namespace RestAssuredNet.Tests
+namespace RestAssured.Net.Tests
 {
     /// <summary>
     /// Examples of RestAssuredNet usage.

--- a/RestAssured.Net.Tests/JsonSchemaValidationTests.cs
+++ b/RestAssured.Net.Tests/JsonSchemaValidationTests.cs
@@ -13,13 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
 using Newtonsoft.Json.Schema;
 using NUnit.Framework;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using static RestAssuredNet.RestAssuredNet;
 
-namespace RestAssuredNet.Tests
+namespace RestAssured.Net.Tests
 {
     /// <summary>
     /// Examples of RestAssuredNet usage.
@@ -76,7 +77,7 @@ namespace RestAssuredNet.Tests
         {
             this.CreateStubForJsonSchemaValidationMismatch();
 
-            RA.Exceptions.AssertionException ae = Assert.Throws<RA.Exceptions.AssertionException>(() =>
+            var ae = Assert.Throws<RestAssured.Net.RA.Exceptions.AssertionException>(() =>
             {
                 Given()
                 .When()
@@ -98,7 +99,7 @@ namespace RestAssuredNet.Tests
         {
             this.CreateStubForJsonSchemaValidationMismatch();
 
-            RA.Exceptions.ResponseVerificationException rve = Assert.Throws<RA.Exceptions.ResponseVerificationException>(() =>
+            var rve = Assert.Throws<RestAssured.Net.RA.Exceptions.ResponseVerificationException>(() =>
             {
                 Given()
                 .When()
@@ -120,7 +121,7 @@ namespace RestAssuredNet.Tests
         {
             this.CreateStubForJsonSchemaUnexpectedResponseContentType();
 
-            RA.Exceptions.ResponseVerificationException rve = Assert.Throws<RA.Exceptions.ResponseVerificationException>(() =>
+            var rve = Assert.Throws<RestAssured.Net.RA.Exceptions.ResponseVerificationException>(() =>
             {
                 Given()
                 .When()

--- a/RestAssured.Net.Tests/LoggingTests.cs
+++ b/RestAssured.Net.Tests/LoggingTests.cs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
 using System.Collections.Generic;
 using NUnit.Framework;
 using RestAssured.Net.Tests.Models;
@@ -20,7 +21,7 @@ using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using static RestAssuredNet.RestAssuredNet;
 
-namespace RestAssuredNet.Tests
+namespace RestAssured.Net.Tests
 {
     /// <summary>
     /// Examples of RestAssuredNet usage.

--- a/RestAssured.Net.Tests/PathParameterTests.cs
+++ b/RestAssured.Net.Tests/PathParameterTests.cs
@@ -13,13 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
 using System.Collections.Generic;
 using NUnit.Framework;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using static RestAssuredNet.RestAssuredNet;
 
-namespace RestAssuredNet.Tests
+namespace RestAssured.Net.Tests
 {
     /// <summary>
     /// Examples of RestAssuredNet usage, focusing on path parameters.

--- a/RestAssured.Net.Tests/QueryParameterTests.cs
+++ b/RestAssured.Net.Tests/QueryParameterTests.cs
@@ -13,13 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
 using System.Collections.Generic;
 using NUnit.Framework;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using static RestAssuredNet.RestAssuredNet;
 
-namespace RestAssuredNet.Tests
+namespace RestAssured.Net.Tests
 {
     /// <summary>
     /// Examples of RestAssuredNet usage, focusing on query parameters.

--- a/RestAssured.Net.Tests/RequestBodySerializationTests.cs
+++ b/RestAssured.Net.Tests/RequestBodySerializationTests.cs
@@ -13,16 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
 using System.Collections.Generic;
 using NUnit.Framework;
 using RestAssured.Net.Tests.Models;
-using RestAssuredNet.RA.Exceptions;
 using WireMock.Matchers;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using static RestAssuredNet.RestAssuredNet;
 
-namespace RestAssuredNet.Tests
+namespace RestAssured.Net.Tests
 {
     /// <summary>
     /// Examples of RestAssuredNet usage.
@@ -157,7 +157,7 @@ namespace RestAssuredNet.Tests
         {
             this.CreateStubForXmlRequestBody();
 
-            RequestCreationException rce = Assert.Throws<RequestCreationException>(() =>
+            var rce = Assert.Throws<RestAssured.Net.RA.Exceptions.RequestCreationException>(() =>
             {
                 Given()
                 .ContentType("application/something")

--- a/RestAssured.Net.Tests/RequestBodyTests.cs
+++ b/RestAssured.Net.Tests/RequestBodyTests.cs
@@ -13,13 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
 using NUnit.Framework;
 using WireMock.Matchers;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using static RestAssuredNet.RestAssuredNet;
 
-namespace RestAssuredNet.Tests
+namespace RestAssured.Net.Tests
 {
     /// <summary>
     /// Examples of RestAssuredNet usage.

--- a/RestAssured.Net.Tests/RequestHeaderTests.cs
+++ b/RestAssured.Net.Tests/RequestHeaderTests.cs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
 using System.Collections.Generic;
 using System.Text;
 using NUnit.Framework;
@@ -21,7 +22,7 @@ using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using static RestAssuredNet.RestAssuredNet;
 
-namespace RestAssuredNet.Tests
+namespace RestAssured.Net.Tests
 {
     /// <summary>
     /// Examples of RestAssuredNet usage.

--- a/RestAssured.Net.Tests/RequestSpecificationTests.cs
+++ b/RestAssured.Net.Tests/RequestSpecificationTests.cs
@@ -13,15 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
+using System.Text;
 using NUnit.Framework;
 using RestAssured.Net.RA.Builders;
-using System.Text;
 using WireMock.Matchers;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using static RestAssuredNet.RestAssuredNet;
 
-namespace RestAssuredNet.Tests
+namespace RestAssured.Net.Tests
 {
     /// <summary>
     /// Examples of RestAssuredNet usage.
@@ -158,7 +159,7 @@ namespace RestAssuredNet.Tests
         {
             this.CreateStubForRequestSpecification();
 
-            RA.Exceptions.RequestCreationException rce = Assert.Throws<RA.Exceptions.RequestCreationException>(() =>
+            var rce = Assert.Throws<RestAssured.Net.RA.Exceptions.RequestCreationException>(() =>
             {
                 Given()
                 .Spec(this.incorrectHostNameSpecification)

--- a/RestAssured.Net.Tests/ResponseBodyDeserializationTests.cs
+++ b/RestAssured.Net.Tests/ResponseBodyDeserializationTests.cs
@@ -13,15 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
 using System.Collections.Generic;
 using NUnit.Framework;
 using RestAssured.Net.Tests.Models;
-using RestAssuredNet.RA.Exceptions;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using static RestAssuredNet.RestAssuredNet;
 
-namespace RestAssuredNet.Tests
+namespace RestAssured.Net.Tests
 {
     /// <summary>
     /// Examples of RestAssuredNet usage.
@@ -76,7 +76,7 @@ namespace RestAssuredNet.Tests
         {
             this.CreateStubForXmlResponseBodyWithUnrecognizedContentType();
 
-            DeserializationException de = Assert.Throws<DeserializationException>(() =>
+            var de = Assert.Throws<RestAssured.Net.RA.Exceptions.DeserializationException>(() =>
             {
                 Location responseLocation = (Location)Given()
                 .When()

--- a/RestAssured.Net.Tests/ResponseBodyJsonVerificationTests.cs
+++ b/RestAssured.Net.Tests/ResponseBodyJsonVerificationTests.cs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
 using System.Collections.Generic;
 using NUnit.Framework;
 using RestAssured.Net.Tests.Models;
@@ -20,7 +21,7 @@ using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using static RestAssuredNet.RestAssuredNet;
 
-namespace RestAssuredNet.Tests
+namespace RestAssured.Net.Tests
 {
     /// <summary>
     /// Examples of RestAssuredNet usage.
@@ -54,7 +55,7 @@ namespace RestAssuredNet.Tests
         {
             this.CreateStubForJsonResponseBody();
 
-            RA.Exceptions.AssertionException ae = Assert.Throws<RA.Exceptions.AssertionException>(() =>
+            var ae = Assert.Throws<RestAssured.Net.RA.Exceptions.AssertionException>(() =>
             {
                 Given()
                 .When()
@@ -93,7 +94,7 @@ namespace RestAssuredNet.Tests
         {
             this.CreateStubForJsonResponseBody();
 
-            RA.Exceptions.AssertionException ae = Assert.Throws<RA.Exceptions.AssertionException>(() =>
+            var ae = Assert.Throws<RestAssured.Net.RA.Exceptions.AssertionException>(() =>
             {
                 Given()
                 .When()
@@ -132,7 +133,7 @@ namespace RestAssuredNet.Tests
         {
             this.CreateStubForJsonResponseBody();
 
-            RA.Exceptions.AssertionException ae = Assert.Throws<RA.Exceptions.AssertionException>(() =>
+            var ae = Assert.Throws<RestAssured.Net.RA.Exceptions.AssertionException>(() =>
             {
                 Given()
                 .When()
@@ -154,7 +155,7 @@ namespace RestAssuredNet.Tests
         {
             this.CreateStubForJsonResponseBody();
 
-            RA.Exceptions.AssertionException ae = Assert.Throws<RA.Exceptions.AssertionException>(() =>
+            var ae = Assert.Throws<RestAssured.Net.RA.Exceptions.AssertionException>(() =>
             {
                 Given()
                 .When()
@@ -193,7 +194,7 @@ namespace RestAssuredNet.Tests
         {
             this.CreateStubForJsonResponseBody();
 
-            RA.Exceptions.AssertionException ae = Assert.Throws<RA.Exceptions.AssertionException>(() =>
+            var ae = Assert.Throws<RestAssured.Net.RA.Exceptions.AssertionException>(() =>
             {
                 Given()
                 .When()

--- a/RestAssured.Net.Tests/ResponseBodyVerificationTests.cs
+++ b/RestAssured.Net.Tests/ResponseBodyVerificationTests.cs
@@ -13,16 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
-using System.Collections.Generic;
-using NHamcrest;
+
 using NUnit.Framework;
-using RestAssured.Net.Tests.Models;
-using RestAssuredNet.RA.Exceptions;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using static RestAssuredNet.RestAssuredNet;
 
-namespace RestAssuredNet.Tests
+namespace RestAssured.Net.Tests
 {
     /// <summary>
     /// Examples of RestAssuredNet usage.
@@ -94,7 +91,7 @@ namespace RestAssuredNet.Tests
         {
             this.CreateStubForPlaintextResponseBody();
 
-            RA.Exceptions.AssertionException ae = Assert.Throws<RA.Exceptions.AssertionException>(() =>
+            var ae = Assert.Throws<RestAssured.Net.RA.Exceptions.AssertionException>(() =>
             {
                 Given()
                 .When()
@@ -116,7 +113,7 @@ namespace RestAssuredNet.Tests
         {
             this.CreateStubForJsonStringResponseBody();
 
-            RA.Exceptions.AssertionException ae = Assert.Throws<RA.Exceptions.AssertionException>(() =>
+            var ae = Assert.Throws<RestAssured.Net.RA.Exceptions.AssertionException>(() =>
             {
                 Given()
                 .When()
@@ -138,7 +135,7 @@ namespace RestAssuredNet.Tests
         {
             this.CreateStubForUnknownContentType();
 
-            ResponseVerificationException rve = Assert.Throws<ResponseVerificationException>(() =>
+            var rve = Assert.Throws<RestAssured.Net.RA.Exceptions.ResponseVerificationException>(() =>
             {
                 Given()
                 .When()

--- a/RestAssured.Net.Tests/ResponseBodyXmlVerificationTests.cs
+++ b/RestAssured.Net.Tests/ResponseBodyXmlVerificationTests.cs
@@ -13,12 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
 using NUnit.Framework;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using static RestAssuredNet.RestAssuredNet;
 
-namespace RestAssuredNet.Tests
+namespace RestAssured.Net.Tests
 {
     /// <summary>
     /// Examples of RestAssuredNet usage.
@@ -88,7 +89,7 @@ namespace RestAssuredNet.Tests
         {
             this.CreateStubForXmlResponseBody();
 
-            RA.Exceptions.AssertionException ae = Assert.Throws<RA.Exceptions.AssertionException>(() =>
+            var ae = Assert.Throws<RestAssured.Net.RA.Exceptions.AssertionException>(() =>
             {
                 Given()
                 .When()
@@ -111,7 +112,7 @@ namespace RestAssuredNet.Tests
         {
             this.CreateStubForXmlResponseBody();
 
-            RA.Exceptions.ResponseVerificationException rve = Assert.Throws<RA.Exceptions.ResponseVerificationException>(() =>
+            var rve = Assert.Throws<RestAssured.Net.RA.Exceptions.ResponseVerificationException>(() =>
             {
                 Given()
                 .When()
@@ -150,7 +151,7 @@ namespace RestAssuredNet.Tests
         {
             this.CreateStubForXmlResponseBody();
 
-            RA.Exceptions.AssertionException ae = Assert.Throws<RA.Exceptions.AssertionException>(() =>
+            var ae = Assert.Throws<RestAssured.Net.RA.Exceptions.AssertionException>(() =>
             {
                 Given()
                 .When()

--- a/RestAssured.Net.Tests/ResponseHeaderVerificationTests.cs
+++ b/RestAssured.Net.Tests/ResponseHeaderVerificationTests.cs
@@ -13,12 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
 using NUnit.Framework;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using static RestAssuredNet.RestAssuredNet;
 
-namespace RestAssuredNet.Tests
+namespace RestAssured.Net.Tests
 {
     /// <summary>
     /// Examples of RestAssuredNet usage.
@@ -70,7 +71,7 @@ namespace RestAssuredNet.Tests
         {
             this.CreateStubForCustomSingleResponseHeader();
 
-            RA.Exceptions.AssertionException ae = Assert.Throws<RA.Exceptions.AssertionException>(() =>
+            var ae = Assert.Throws<RestAssured.Net.RA.Exceptions.AssertionException>(() =>
             {
                 Given()
                 .When()
@@ -92,7 +93,7 @@ namespace RestAssuredNet.Tests
         {
             this.CreateStubForCustomSingleResponseHeader();
 
-            RA.Exceptions.AssertionException ae = Assert.Throws<RA.Exceptions.AssertionException>(() =>
+            var ae = Assert.Throws<RestAssured.Net.RA.Exceptions.AssertionException>(() =>
             {
                 Given()
                 .When()
@@ -114,7 +115,7 @@ namespace RestAssuredNet.Tests
         {
             this.CreateStubForCustomSingleResponseHeader();
 
-            RA.Exceptions.AssertionException ae = Assert.Throws<RA.Exceptions.AssertionException>(() =>
+            var ae = Assert.Throws<RestAssured.Net.RA.Exceptions.AssertionException>(() =>
             {
                 Given()
                 .When()
@@ -188,7 +189,7 @@ namespace RestAssuredNet.Tests
         {
             this.CreateStubForCustomResponseContentTypeHeader();
 
-            RA.Exceptions.AssertionException ae = Assert.Throws<RA.Exceptions.AssertionException>(() =>
+            var ae = Assert.Throws<RestAssured.Net.RA.Exceptions.AssertionException>(() =>
             {
                 Given()
                 .When()
@@ -210,7 +211,7 @@ namespace RestAssuredNet.Tests
         {
             this.CreateStubForCustomResponseContentTypeHeader();
 
-            RA.Exceptions.AssertionException ae = Assert.Throws<RA.Exceptions.AssertionException>(() =>
+            var ae = Assert.Throws<RestAssured.Net.RA.Exceptions.AssertionException>(() =>
             {
                 Given()
                 .When()

--- a/RestAssured.Net.Tests/ResponseJsonValueExtractionTests.cs
+++ b/RestAssured.Net.Tests/ResponseJsonValueExtractionTests.cs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -24,7 +25,7 @@ using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using static RestAssuredNet.RestAssuredNet;
 
-namespace RestAssuredNet.Tests
+namespace RestAssured.Net.Tests
 {
     /// <summary>
     /// Examples of RestAssuredNet usage.
@@ -125,7 +126,7 @@ namespace RestAssuredNet.Tests
         {
             this.CreateStubForJsonResponseWithBodyAndHeaders();
 
-            RA.Exceptions.AssertionException ae = Assert.Throws<RA.Exceptions.AssertionException>(() =>
+            var ae = Assert.Throws<RestAssured.Net.RA.Exceptions.AssertionException>(() =>
             {
                 Given()
                 .When()
@@ -166,9 +167,9 @@ namespace RestAssuredNet.Tests
         {
             this.CreateStubForJsonResponseWithBodyAndHeaders();
 
-            RA.Exceptions.ExtractionException ee = Assert.Throws<RA.Exceptions.ExtractionException>(() =>
+            var ee = Assert.Throws<RestAssured.Net.RA.Exceptions.ExtractionException>(() =>
             {
-                string responseHeaderValue = Given()
+                Given()
                 .When()
                 .Get("http://localhost:9876/json-response-body")
                 .Then()

--- a/RestAssured.Net.Tests/ResponseStatusCodeVerificationTests.cs
+++ b/RestAssured.Net.Tests/ResponseStatusCodeVerificationTests.cs
@@ -13,13 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
 using System.Net;
 using NUnit.Framework;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using static RestAssuredNet.RestAssuredNet;
 
-namespace RestAssuredNet.Tests
+namespace RestAssured.Net.Tests
 {
     /// <summary>
     /// Examples of RestAssuredNet usage.
@@ -118,7 +119,7 @@ namespace RestAssuredNet.Tests
         {
             this.CreateStubForHttpOK();
 
-            RA.Exceptions.AssertionException ae = Assert.Throws<RA.Exceptions.AssertionException>(() =>
+            var ae = Assert.Throws<RestAssured.Net.RA.Exceptions.AssertionException>(() =>
             {
                 Given()
                 .When()

--- a/RestAssured.Net.Tests/ResponseXmlValueExtractionTests.cs
+++ b/RestAssured.Net.Tests/ResponseXmlValueExtractionTests.cs
@@ -13,13 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
 using System.Collections.Generic;
 using NUnit.Framework;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using static RestAssuredNet.RestAssuredNet;
 
-namespace RestAssuredNet.Tests
+namespace RestAssured.Net.Tests
 {
     /// <summary>
     /// Examples of RestAssuredNet usage.
@@ -79,7 +80,7 @@ namespace RestAssuredNet.Tests
         {
             this.CreateStubForXmlResponseWithBodyAndHeaders();
 
-            RA.Exceptions.ExtractionException ee = Assert.Throws<RA.Exceptions.ExtractionException>(() =>
+            var ee = Assert.Throws<RestAssured.Net.RA.Exceptions.ExtractionException>(() =>
             {
                 Given()
                 .When()

--- a/RestAssured.Net.Tests/TestBase.cs
+++ b/RestAssured.Net.Tests/TestBase.cs
@@ -13,10 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
 using NUnit.Framework;
 using WireMock.Server;
 
-namespace RestAssuredNet.Tests
+namespace RestAssured.Net.Tests
 {
     /// <summary>
     /// Base class containing common test logic.

--- a/RestAssured.Net.Tests/TestBaseHttps.cs
+++ b/RestAssured.Net.Tests/TestBaseHttps.cs
@@ -13,10 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
 using NUnit.Framework;
 using WireMock.Server;
 
-namespace RestAssuredNet.Tests
+namespace RestAssured.Net.Tests
 {
     /// <summary>
     /// Base class containing common test logic.

--- a/RestAssured.Net.Tests/TimeoutTests.cs
+++ b/RestAssured.Net.Tests/TimeoutTests.cs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
 using System;
 using NUnit.Framework;
 using RestAssured.Net.RA.Builders;
@@ -20,7 +21,7 @@ using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using static RestAssuredNet.RestAssuredNet;
 
-namespace RestAssuredNet.Tests
+namespace RestAssured.Net.Tests
 {
     /// <summary>
     /// Examples of RestAssuredNet usage.
@@ -87,7 +88,7 @@ namespace RestAssuredNet.Tests
         {
             this.CreateStubForTimeoutNok();
 
-            RA.Exceptions.HttpRequestProcessorException hrpe = Assert.Throws<RA.Exceptions.HttpRequestProcessorException>(() =>
+            var hrpe = Assert.Throws<RestAssured.Net.RA.Exceptions.HttpRequestProcessorException>(() =>
             {
                 Given()
                 .Timeout(TimeSpan.FromSeconds(2))
@@ -109,7 +110,7 @@ namespace RestAssuredNet.Tests
         {
             this.CreateStubForTimeoutNok();
 
-            RA.Exceptions.HttpRequestProcessorException hrpe = Assert.Throws<RA.Exceptions.HttpRequestProcessorException>(() =>
+            var hrpe = Assert.Throws<RestAssured.Net.RA.Exceptions.HttpRequestProcessorException>(() =>
             {
                 Given()
                 .Spec(this.requestSpecification)

--- a/RestAssured.Net.Tests/UserAgentTests.cs
+++ b/RestAssured.Net.Tests/UserAgentTests.cs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
 using System.Net.Http.Headers;
 using NUnit.Framework;
 using RestAssured.Net.RA.Builders;
@@ -20,7 +21,7 @@ using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using static RestAssuredNet.RestAssuredNet;
 
-namespace RestAssuredNet.Tests
+namespace RestAssured.Net.Tests
 {
     /// <summary>
     /// Examples of RestAssuredNet usage.

--- a/RestAssured.Net/RA/Builders/RequestSpecBuilder.cs
+++ b/RestAssured.Net/RA/Builders/RequestSpecBuilder.cs
@@ -13,14 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
-using System;
-using System.Collections.Generic;
-using System.Net;
-using System.Net.Http.Headers;
-using System.Text;
-
 namespace RestAssured.Net.RA.Builders
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Net;
+    using System.Net.Http.Headers;
+    using System.Text;
+
     /// <summary>
     /// A builder class to construct a new instance of the <see cref="RequestSpecification"/> class.
     /// </summary>

--- a/RestAssured.Net/RA/Exceptions/AssertionException.cs
+++ b/RestAssured.Net/RA/Exceptions/AssertionException.cs
@@ -13,10 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
-using System;
-
-namespace RestAssuredNet.RA.Exceptions
+namespace RestAssured.Net.RA.Exceptions
 {
+    using System;
+
     /// <summary>
     /// An exception to be thrown whenever a response verification fails.
     /// </summary>

--- a/RestAssured.Net/RA/Exceptions/DeserializationException.cs
+++ b/RestAssured.Net/RA/Exceptions/DeserializationException.cs
@@ -13,9 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
 using System;
 
-namespace RestAssuredNet.RA.Exceptions
+namespace RestAssured.Net.RA.Exceptions
 {
     /// <summary>
     /// An exception to be thrown whenever response deserialization fails.

--- a/RestAssured.Net/RA/Exceptions/ExtractionException.cs
+++ b/RestAssured.Net/RA/Exceptions/ExtractionException.cs
@@ -13,10 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
-using System;
-
-namespace RestAssuredNet.RA.Exceptions
+namespace RestAssured.Net.RA.Exceptions
 {
+    using System;
+    
     /// <summary>
     /// An exception to be thrown whenever a response value extraction fails.
     /// </summary>

--- a/RestAssured.Net/RA/Exceptions/HttpRequestProcessorException.cs
+++ b/RestAssured.Net/RA/Exceptions/HttpRequestProcessorException.cs
@@ -13,10 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
-using System;
 
-namespace RestAssuredNet.RA.Exceptions
+namespace RestAssured.Net.RA.Exceptions
 {
+    using System;
+
     /// <summary>
     /// An exception to be thrown whenever sending an HTTP request fails.
     /// </summary>

--- a/RestAssured.Net/RA/Exceptions/RequestCreationException.cs
+++ b/RestAssured.Net/RA/Exceptions/RequestCreationException.cs
@@ -13,10 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
-using System;
-
-namespace RestAssuredNet.RA.Exceptions
+namespace RestAssured.Net.RA.Exceptions
 {
+    using System;
+
     /// <summary>
     /// An exception to be thrown whenever creation of a suitable request fails.
     /// </summary>

--- a/RestAssured.Net/RA/Exceptions/ResponseVerificationException.cs
+++ b/RestAssured.Net/RA/Exceptions/ResponseVerificationException.cs
@@ -13,9 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
 using System;
 
-namespace RestAssuredNet.RA.Exceptions
+namespace RestAssured.Net.RA.Exceptions
 {
     /// <summary>
     /// An exception to be thrown whenever validation of a response fails for technical reasons.

--- a/RestAssured.Net/RA/ExecutableRequest.cs
+++ b/RestAssured.Net/RA/ExecutableRequest.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+using RestAssured.Net.RA.Exceptions;
+
 namespace RestAssured.Net.RA
 {
     using System;
@@ -31,7 +33,6 @@ namespace RestAssured.Net.RA
     using RestAssured.Net.RA.Builders;
     using RestAssured.Net.RA.Internal;
     using RestAssuredNet.RA;
-    using RestAssuredNet.RA.Exceptions;
     using Stubble.Core;
     using Stubble.Core.Builders;
 

--- a/RestAssured.Net/RA/ExtractableResponse.cs
+++ b/RestAssured.Net/RA/ExtractableResponse.cs
@@ -13,6 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
+using RestAssured.Net.RA.Exceptions;
+
 namespace RestAssured.Net.RA
 {
     using System.Collections.Generic;
@@ -20,7 +23,6 @@ namespace RestAssured.Net.RA
     using System.Net.Http;
     using System.Xml;
     using Newtonsoft.Json.Linq;
-    using RestAssuredNet.RA.Exceptions;
 
     /// <summary>
     /// A class representing an <see cref="HttpResponseMessage"/> from which values can be extracted.

--- a/RestAssured.Net/RA/Internal/HttpRequestProcessor.cs
+++ b/RestAssured.Net/RA/Internal/HttpRequestProcessor.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+using RestAssured.Net.RA.Exceptions;
+
 namespace RestAssured.Net.RA.Internal
 {
     using System;
@@ -22,7 +24,6 @@ namespace RestAssured.Net.RA.Internal
     using System.Net.Http;
     using System.Threading.Tasks;
     using RestAssuredNet.RA;
-    using RestAssuredNet.RA.Exceptions;
 
     /// <summary>
     /// The <see cref="HttpRequestProcessor"/> class is responsible for sending HTTP requests.

--- a/RestAssured.Net/RA/Internal/RequestSpecificationProcessor.cs
+++ b/RestAssured.Net/RA/Internal/RequestSpecificationProcessor.cs
@@ -19,7 +19,7 @@ using System.Net;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
 using RestAssured.Net.RA.Builders;
-using RestAssuredNet.RA.Exceptions;
+using RestAssured.Net.RA.Exceptions;
 
 namespace RestAssured.Net.RA.Internal
 {

--- a/RestAssured.Net/RA/VerifiableResponse.cs
+++ b/RestAssured.Net/RA/VerifiableResponse.cs
@@ -27,8 +27,8 @@ using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Schema;
 using NHamcrest;
 using RestAssured.Net.RA;
+using RestAssured.Net.RA.Exceptions;
 using RestAssured.Net.RA.Internal;
-using RestAssuredNet.RA.Exceptions;
 
 namespace RestAssuredNet.RA
 {


### PR DESCRIPTION
Namespaces now match the folder structure. Although.. I doubt that's desirable? If so, rearrange the folder structure to reflect the desired namespace structure. Do note that you can use the internal keyword, not every class needs to be public. Also note that you can still test internal classes with a concept called friendly assemblies.

Next up:
- Fixing the compiler warnings
- Fixing the access levels
- Some methods have too high a cognitive complexity, that needs fixing...

Holler!!