### PR TITLE
Properly target frameworks in jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
 
+      - name: List installed .NET SDKs
+        run: dotnet --list-sdks
+
       - name: Restore project dependencies
         run: dotnet restore
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ['3.1.x', '6.0.x', '7.0.x']
+        dotnet-version: [3.1.x, 6.0.x, 7.0.x]
+        include:
+          - dotnet-version: 3.1.x
+            framework: netcoreapp3.1
+          - dotnet-version: 6.0.x
+            framework: net6.0
+          - dotnet-version: 7.0.x
+            framework: net7.0
 
     steps:
       - uses: actions/checkout@v3
@@ -33,5 +40,22 @@ jobs:
       - name: Restore project dependencies
         run: dotnet restore
 
-      - name: Run tests
-        run: dotnet test --no-restore --verbosity normal
+      - name: Build (${{ matrix.framework }})
+        run: dotnet build --framework ${{ matrix.framework }} --no-restore
+
+      - name: Run tests (${{ matrix.framework }})
+        run: dotnet test --framework ${{ matrix.framework }} --no-restore --no-build --verbosity normal
+
+      - name: Rebuild
+        if: contains(matrix.framework, 'net7.0')
+        run: dotnet build --no-restore
+
+      - name: Ensure NuGet package is generated
+        if: contains(matrix.framework, 'net7.0')
+        run: |
+          FILE=./RestAssured.Net/bin/Debug/RestAssured.Net.*.nupkg
+          if compgen -G $FILE > /dev/null; then
+            echo "$FILE exists."
+          else
+            exit 1;
+          fi

--- a/RestAssured.Net.Tests/RestAssured.Net.Tests.csproj
+++ b/RestAssured.Net.Tests/RestAssured.Net.Tests.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <Nullable>enable</Nullable>
+    <TargetFrameworks>net6.0;net7.0;netcoreapp3.1</TargetFrameworks>
+    <Nullable>disable</Nullable>
     <RootNamespace>RestAssured.Tests</RootNamespace>
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
3.1.x -> Build using netcoreapp3.1 -> Run tests using netcoreapp3.1
6.0.x -> Build using net6.0 -> Run tests using net6.0
7.0.x -> Build using net7.0 -> Run tests using net7.0