### PR TITLE
Add DeserializeTo<T>

### DIFF
--- a/RestAssured.Net.Tests/ResponseBodyDeserializationTests.cs
+++ b/RestAssured.Net.Tests/ResponseBodyDeserializationTests.cs
@@ -101,6 +101,30 @@ namespace RestAssured.Tests
 
         /// <summary>
         /// A test demonstrating RestAssuredNet syntax for deserializing
+        /// a JSON response into an object when performing an HTTP GET.
+        /// </summary>
+        [Test]
+        public void ObjectCanBeDeserializedAsTypeFromJson()
+        {
+            this.CreateStubForJsonResponseBody();
+
+            Location responseLocation = Given()
+                .When()
+                .Get($"{MOCK_SERVER_BASE_URL}/json-deserialization")
+                .DeserializeTo<Location>();
+
+            Assert.That(responseLocation.Country, Is.EqualTo(this.country));
+            Assert.That(responseLocation.Places?.Count, Is.EqualTo(2));
+
+            Place firstPlace = responseLocation.Places!.First();
+
+            Assert.That(firstPlace.Name, Is.EqualTo(this.placeName));
+            Assert.That(firstPlace.Inhabitants, Is.EqualTo(this.placeInhabitants));
+            Assert.That(firstPlace.IsCapital, Is.EqualTo(this.isCapital));
+        }
+
+        /// <summary>
+        /// A test demonstrating RestAssuredNet syntax for deserializing
         /// a JSON response into an object when performing an HTTP GET
         /// after performing some initial verifications.
         /// </summary>

--- a/RestAssured.Net/Response/VerifiableResponse.cs
+++ b/RestAssured.Net/Response/VerifiableResponse.cs
@@ -718,9 +718,21 @@ namespace RestAssured.Response
         /// <param name="type">The object type to deserialize into.</param>
         /// <param name="deserializeAs">Indicates how to interpret the response content when deserializing.</param>
         /// <returns>The deserialized response object.</returns>
-        public object DeserializeTo(Type type, DeserializeAs deserializeAs = DeserializeAs.UseResponseContentTypeHeaderValue)
+        public object? DeserializeTo(Type type, DeserializeAs deserializeAs = DeserializeAs.UseResponseContentTypeHeaderValue)
         {
             return Deserializer.DeserializeResponseInto(this.Response, type, deserializeAs, this.jsonSerializerSettings);
+        }
+
+        /// <summary>
+        /// Deserializes the response content into the specified type and returns it.
+        /// </summary>
+        /// <typeparam name="T">The type to deserialize the response body into.</typeparam>
+        /// <param name="deserializeAs">Indicates how to interpret the response content when deserializing.</param>
+        /// <returns>The deserialized response object.</returns>
+        public T? DeserializeTo<T>(DeserializeAs deserializeAs = DeserializeAs.UseResponseContentTypeHeaderValue)
+            where T : class
+        {
+            return Deserializer.DeserializeResponseInto<T>(this.Response, deserializeAs, this.jsonSerializerSettings);
         }
 
         /// <summary>


### PR DESCRIPTION
Add generic DeserializeTo

- Using `.Result` on async task is not the best practice, so I changed this in this PR, however this should be changed in the whole project, I can create a new PR if needed
- I tried to comply to your coding standard, however it's quite different as I'm used to...
- I did only add 1 extra unit test, if more is needed, I can add it