### PR TITLE
Add optional custom error message to all assertion methods (fixes #146)

### DIFF
--- a/RestAssured.Net.Tests/ResponseBodyJsonVerificationTests.cs
+++ b/RestAssured.Net.Tests/ResponseBodyJsonVerificationTests.cs
@@ -365,6 +365,28 @@ namespace RestAssured.Tests
         }
 
         /// <summary>
+        /// Verifies that a custom error message is used when the JsonPath expression
+        /// does not yield any results.
+        /// </summary>
+        [Test]
+        public void CustomErrorMessageIsUsedWhenJsonPathDoesNotYieldAnyResults()
+        {
+            this.CreateStubForJsonResponseBody();
+
+            var rve = Assert.Throws<ResponseVerificationException>(() =>
+            {
+                Given()
+                    .When()
+                    .Get($"{MOCK_SERVER_BASE_URL}/json-response-body")
+                    .Then()
+                    .StatusCode(200)
+                    .Body("$.Places[0].DoesNotExist", NHamcrest.Is.False(), errorMessage: "Custom no-results message");
+            });
+
+            Assert.That(rve?.Message, Is.EqualTo("Custom no-results message: JsonPath expression '$.Places[0].DoesNotExist' did not yield any results."));
+        }
+
+        /// <summary>
         /// Verifies that a custom error message is used when a JSON path body element
         /// does not match the expected NHamcrest matcher.
         /// </summary>

--- a/RestAssured.Net.Tests/ResponseBodyJsonVerificationTests.cs
+++ b/RestAssured.Net.Tests/ResponseBodyJsonVerificationTests.cs
@@ -365,9 +365,6 @@ namespace RestAssured.Tests
         }
 
         /// <summary>
-        /// Creates the stub response for the JSON response body example.
-        /// </summary>
-        /// <summary>
         /// Verifies that a custom error message is used when a JSON path body element
         /// does not match the expected NHamcrest matcher.
         /// </summary>
@@ -389,6 +386,9 @@ namespace RestAssured.Tests
             Assert.That(rve?.Message, Is.EqualTo("Expected \"NonExistentCity\""));
         }
 
+        /// <summary>
+        /// Creates the stub response for the JSON response body example.
+        /// </summary>
         private void CreateStubForJsonResponseBody()
         {
             this.Server?.Given(Request.Create().WithPath("/json-response-body").UsingGet())

--- a/RestAssured.Net.Tests/ResponseBodyJsonVerificationTests.cs
+++ b/RestAssured.Net.Tests/ResponseBodyJsonVerificationTests.cs
@@ -367,6 +367,28 @@ namespace RestAssured.Tests
         /// <summary>
         /// Creates the stub response for the JSON response body example.
         /// </summary>
+        /// <summary>
+        /// Verifies that a custom error message is used when a JSON path body element
+        /// does not match the expected NHamcrest matcher.
+        /// </summary>
+        [Test]
+        public void TemplatedCustomErrorMessageCanBeSpecifiedWhenVerifyingJsonBodyElement()
+        {
+            this.CreateStubForJsonResponseBody();
+
+            var rve = Assert.Throws<ResponseVerificationException>(() =>
+            {
+                Given()
+                    .When()
+                    .Get($"{MOCK_SERVER_BASE_URL}/json-response-body")
+                    .Then()
+                    .StatusCode(200)
+                    .Body("$.Places[0].Name", NHamcrest.Is.EqualTo("NonExistentCity"), errorMessage: "Expected [expected]");
+            });
+
+            Assert.That(rve?.Message, Is.EqualTo("Expected \"NonExistentCity\""));
+        }
+
         private void CreateStubForJsonResponseBody()
         {
             this.Server?.Given(Request.Create().WithPath("/json-response-body").UsingGet())

--- a/RestAssured.Net.Tests/ResponseBodyLengthVerificationTests.cs
+++ b/RestAssured.Net.Tests/ResponseBodyLengthVerificationTests.cs
@@ -139,6 +139,29 @@ namespace RestAssured.Tests
         }
 
         /// <summary>
+        /// A test demonstrating RestAssuredNet syntax for verifying
+        /// a response body length using a templated custom error message,
+        /// that the exception contains the correctly formatted message.
+        /// </summary>
+        [Test]
+        public void TemplatedCustomErrorMessageCanBeSpecifiedWhenVerifyingResponseBodyLength()
+        {
+            this.CreateStubForJsonResponseBody();
+
+            var rve = Assert.Throws<ResponseVerificationException>(() =>
+            {
+                Given()
+                .When()
+                .Get($"{MOCK_SERVER_BASE_URL}/json-response-body")
+                .Then()
+                .StatusCode(200)
+                .ResponseBodyLength(NHamcrest.Is.LessThan(25), "Expected [expected]");
+            });
+
+            Assert.That(rve?.Message, Is.EqualTo("Expected less than 25"));
+        }
+
+        /// <summary>
         /// Creates the stub response for the JSON response body extraction examples.
         /// </summary>
         private void CreateStubForJsonResponseBody()

--- a/RestAssured.Net.Tests/ResponseBodyVerificationTests.cs
+++ b/RestAssured.Net.Tests/ResponseBodyVerificationTests.cs
@@ -153,6 +153,50 @@ namespace RestAssured.Tests
             Assert.That(rve?.Message, Is.EqualTo($"Unable to extract elements from response with Content-Type 'application/unknown'"));
         }
 
+        /// <summary>
+        /// Verifies that a custom error message is used when the response body
+        /// does not equal the expected string value.
+        /// </summary>
+        [Test]
+        public void TemplatedCustomErrorMessageCanBeSpecifiedWhenVerifyingBodyAsString()
+        {
+            this.CreateStubForPlaintextResponseBody("small");
+
+            var rve = Assert.Throws<ResponseVerificationException>(() =>
+            {
+                Given()
+                    .When()
+                    .Get($"{MOCK_SERVER_BASE_URL}/plaintext-response-body")
+                    .Then()
+                    .StatusCode(200)
+                    .Body("wrong body", "Expected [expected]");
+            });
+
+            Assert.That(rve?.Message, Is.EqualTo("Expected wrong body"));
+        }
+
+        /// <summary>
+        /// Verifies that a custom error message is used when the response body
+        /// does not match the given NHamcrest matcher.
+        /// </summary>
+        [Test]
+        public void TemplatedCustomErrorMessageCanBeSpecifiedWhenVerifyingBodyUsingNHamcrestMatcher()
+        {
+            this.CreateStubForJsonStringResponseBody();
+
+            var rve = Assert.Throws<ResponseVerificationException>(() =>
+            {
+                Given()
+                    .When()
+                    .Get($"{MOCK_SERVER_BASE_URL}/json-string-response-body")
+                    .Then()
+                    .StatusCode(200)
+                    .Body(NHamcrest.Contains.String("Jane Doe"), "Expected [expected]");
+            });
+
+            Assert.That(rve?.Message, Is.EqualTo("Expected a string containing \"Jane Doe\""));
+        }
+
         private void CreateStubForPlaintextResponseBody(string bodySize)
         {
             switch (bodySize)

--- a/RestAssured.Net.Tests/ResponseBodyXmlVerificationTests.cs
+++ b/RestAssured.Net.Tests/ResponseBodyXmlVerificationTests.cs
@@ -188,6 +188,50 @@ namespace RestAssured.Tests
         }
 
         /// <summary>
+        /// Verifies that a custom error message is used when the element value returned
+        /// by the XPath cannot be converted to the matcher type.
+        /// </summary>
+        [Test]
+        public void CustomErrorMessageIsUsedWhenElementValueCannotBeConvertedToMatcherType()
+        {
+            this.CreateStubForXmlResponseBody();
+
+            var rve = Assert.Throws<ResponseVerificationException>(() =>
+            {
+                Given()
+                    .When()
+                    .Get($"{MOCK_SERVER_BASE_URL}/xml-response-body")
+                    .Then()
+                    .StatusCode(200)
+                    .Body("//Place[1]/Inhabitants", NHamcrest.Is.True(), errorMessage: "Custom conversion message");
+            });
+
+            Assert.That(rve?.Message, Is.EqualTo("Custom conversion message: Response element value " + this.placeInhabitants + " cannot be converted to value of type 'System.Boolean'"));
+        }
+
+        /// <summary>
+        /// Verifies that a custom error message is used when a collection element value
+        /// returned by the XPath cannot be converted to the matcher type.
+        /// </summary>
+        [Test]
+        public void CustomErrorMessageIsUsedWhenCollectionElementValueCannotBeConvertedToMatcherType()
+        {
+            this.CreateStubForXmlResponseBody();
+
+            var rve = Assert.Throws<ResponseVerificationException>(() =>
+            {
+                Given()
+                    .When()
+                    .Get($"{MOCK_SERVER_BASE_URL}/xml-response-body")
+                    .Then()
+                    .StatusCode(200)
+                    .Body("//Place/Inhabitants", NHamcrest.Has.Item(NHamcrest.Is.True()), errorMessage: "Custom collection conversion message");
+            });
+
+            Assert.That(rve?.Message, Is.EqualTo("Custom collection conversion message: Response element value " + this.placeInhabitants + " cannot be converted to object of type System.Boolean"));
+        }
+
+        /// <summary>
         /// A test demonstrating RestAssuredNet syntax for verifying
         /// an XML response body element collection using an NHamcrest matcher.
         /// </summary>

--- a/RestAssured.Net.Tests/ResponseCookieVerificationAndExtractionTests.cs
+++ b/RestAssured.Net.Tests/ResponseCookieVerificationAndExtractionTests.cs
@@ -173,6 +173,30 @@ namespace RestAssured.Tests
         }
 
         /// <summary>
+        /// A test demonstrating RestAssuredNet syntax for verifying
+        /// a cookie value using a templated custom error message,
+        /// that the exception contains the correctly formatted message.
+        /// </summary>
+        [Test]
+        public void TemplatedCustomErrorMessageCanBeSpecifiedWhenVerifyingCookieValue()
+        {
+            this.CreateStubForGenericCookie();
+
+            ResponseVerificationException rve = Assert.Throws<ResponseVerificationException>(() =>
+            {
+                Given()
+                .When()
+                .Get($"{MOCK_SERVER_BASE_URL}/response-with-generic-cookie")
+                .Then()
+                .StatusCode(200)
+                .And()
+                .Cookie("my_cookie", NHamcrest.Is.EqualTo("wrong_value"), "Expected [expected] but got [actual]");
+            });
+
+            Assert.That(rve.Message, Is.EqualTo("Expected \"wrong_value\" but got my_value"));
+        }
+
+        /// <summary>
         /// Creates the stub returning a response with a generic response cookie.
         /// </summary>
         private void CreateStubForGenericCookie()

--- a/RestAssured.Net.Tests/ResponseHeaderVerificationTests.cs
+++ b/RestAssured.Net.Tests/ResponseHeaderVerificationTests.cs
@@ -205,6 +205,98 @@ namespace RestAssured.Tests
         }
 
         /// <summary>
+        /// A test demonstrating RestAssuredNet syntax for verifying
+        /// a response header value using a templated custom error message with
+        /// a string overload, that the exception contains the correctly formatted message.
+        /// </summary>
+        [Test]
+        public void TemplatedCustomErrorMessageCanBeSpecifiedWhenVerifyingHeaderValueAsString()
+        {
+            this.CreateStubForCustomSingleResponseHeader();
+
+            var rve = Assert.Throws<ResponseVerificationException>(() =>
+            {
+                Given()
+                    .When()
+                    .Get($"{MOCK_SERVER_BASE_URL}/custom-response-header")
+                    .Then()
+                    .StatusCode(200)
+                    .Header(this.headerName, "value_does_not_match", "Expected [expected] but got [actual]");
+            });
+
+            Assert.That(rve?.Message, Is.EqualTo("Expected \"value_does_not_match\" but got a_value"));
+        }
+
+        /// <summary>
+        /// A test demonstrating RestAssuredNet syntax for verifying
+        /// a response header value using a templated custom error message with
+        /// an NHamcrest matcher overload, that the exception contains the correctly formatted message.
+        /// </summary>
+        [Test]
+        public void TemplatedCustomErrorMessageCanBeSpecifiedWhenVerifyingHeaderValueUsingNHamcrestMatcher()
+        {
+            this.CreateStubForCustomSingleResponseHeader();
+
+            var rve = Assert.Throws<ResponseVerificationException>(() =>
+            {
+                Given()
+                    .When()
+                    .Get($"{MOCK_SERVER_BASE_URL}/custom-response-header")
+                    .Then()
+                    .StatusCode(200)
+                    .Header(this.headerName, NHamcrest.Contains.String("_wrong"), "Expected [expected] but got [actual]");
+            });
+
+            Assert.That(rve?.Message, Is.EqualTo("Expected a string containing \"_wrong\" but got a_value"));
+        }
+
+        /// <summary>
+        /// A test demonstrating RestAssuredNet syntax for verifying
+        /// the Content-Type header using a templated custom error message with
+        /// a string overload, that the exception contains the correctly formatted message.
+        /// </summary>
+        [Test]
+        public void TemplatedCustomErrorMessageCanBeSpecifiedWhenVerifyingContentTypeAsString()
+        {
+            this.CreateStubForCustomResponseContentTypeHeader();
+
+            var rve = Assert.Throws<ResponseVerificationException>(() =>
+            {
+                Given()
+                    .When()
+                    .Get($"{MOCK_SERVER_BASE_URL}/custom-response-content-type-header")
+                    .Then()
+                    .StatusCode(200)
+                    .ContentType("application/something_else", "Expected [expected] but got [actual]");
+            });
+
+            Assert.That(rve?.Message, Is.EqualTo("Expected \"application/something_else\" but got application/something"));
+        }
+
+        /// <summary>
+        /// A test demonstrating RestAssuredNet syntax for verifying
+        /// the Content-Type header using a templated custom error message with
+        /// an NHamcrest matcher overload, that the exception contains the correctly formatted message.
+        /// </summary>
+        [Test]
+        public void TemplatedCustomErrorMessageCanBeSpecifiedWhenVerifyingContentTypeUsingNHamcrestMatcher()
+        {
+            this.CreateStubForCustomResponseContentTypeHeader();
+
+            var rve = Assert.Throws<ResponseVerificationException>(() =>
+            {
+                Given()
+                    .When()
+                    .Get($"{MOCK_SERVER_BASE_URL}/custom-response-content-type-header")
+                    .Then()
+                    .StatusCode(200)
+                    .ContentType(NHamcrest.Contains.String("wrong_type"), "Expected [expected] but got [actual]");
+            });
+
+            Assert.That(rve?.Message, Is.EqualTo("Expected a string containing \"wrong_type\" but got application/something"));
+        }
+
+        /// <summary>
         /// Creates the stub response for the single response header example.
         /// </summary>
         private void CreateStubForCustomSingleResponseHeader()

--- a/RestAssured.Net.Tests/ResponseTimeVerificationAndExtractionTests.cs
+++ b/RestAssured.Net.Tests/ResponseTimeVerificationAndExtractionTests.cs
@@ -88,6 +88,29 @@ namespace RestAssured.Tests
         }
 
         /// <summary>
+        /// A test demonstrating RestAssuredNet syntax for verifying
+        /// a response time using a templated custom error message,
+        /// that the exception contains the correctly formatted message.
+        /// </summary>
+        [Test]
+        public void TemplatedCustomErrorMessageCanBeSpecifiedWhenVerifyingResponseTime()
+        {
+            this.CreateStubForDelayedResponse();
+
+            var rve = Assert.Throws<ResponseVerificationException>(() =>
+            {
+                Given()
+                .When()
+                .Get($"{MOCK_SERVER_BASE_URL}/delayed-response")
+                .Then()
+                .StatusCode(200)
+                .ResponseTime(NHamcrest.Is.LessThan(TimeSpan.FromMilliseconds(200)), "Expected [expected]");
+            });
+
+            Assert.That(rve?.Message, Is.EqualTo("Expected less than 00:00:00.2000000"));
+        }
+
+        /// <summary>
         /// Creates the stub response for the response time extraction and verification examples.
         /// </summary>
         private void CreateStubForDelayedResponse()

--- a/RestAssured.Net.Tests/ResponseTimeVerificationAndExtractionTests.cs
+++ b/RestAssured.Net.Tests/ResponseTimeVerificationAndExtractionTests.cs
@@ -88,9 +88,8 @@ namespace RestAssured.Tests
         }
 
         /// <summary>
-        /// A test demonstrating RestAssuredNet syntax for verifying
-        /// a response time using a templated custom error message,
-        /// that the exception contains the correctly formatted message.
+        /// A test demonstrating RestAssuredNet syntax for verifying a response time using a templated custom error message,
+        /// and asserting that the thrown exception contains the correctly formatted message.
         /// </summary>
         [Test]
         public void TemplatedCustomErrorMessageCanBeSpecifiedWhenVerifyingResponseTime()

--- a/RestAssured.Net/Response/ErrorMessage.cs
+++ b/RestAssured.Net/Response/ErrorMessage.cs
@@ -1,0 +1,51 @@
+// <copyright file="ErrorMessage.cs" company="On Test Automation">
+// Copyright 2019 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+namespace RestAssured.Response
+{
+    /// <summary>
+    /// Represents an optional custom error message used in assertion failure exceptions
+    /// instead of the default one. Supports Stubble template tokens <c>[expected]</c>
+    /// and <c>[actual]</c> for inserting the matcher and actual value respectively.
+    /// </summary>
+    public readonly struct ErrorMessage
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ErrorMessage"/> struct.
+        /// </summary>
+        /// <param name="value">The error message text.</param>
+        public ErrorMessage(string value)
+        {
+            this.Value = value;
+        }
+
+        /// <summary>
+        /// Gets the error message text, or <c>null</c> if no message was supplied.
+        /// </summary>
+        public string? Value { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether a message was supplied.
+        /// </summary>
+        public bool HasValue => this.Value != null;
+
+        /// <summary>
+        /// Implicitly converts a string to an <see cref="ErrorMessage"/>.
+        /// </summary>
+        /// <param name="value">The string value to convert.</param>
+        public static implicit operator ErrorMessage(string? value) =>
+            value != null ? new ErrorMessage(value) : default;
+    }
+}

--- a/RestAssured.Net/Response/Logging/AssertionMessageBuilder.cs
+++ b/RestAssured.Net/Response/Logging/AssertionMessageBuilder.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AssertionMessageBuilder.cs" company="On Test Automation">
+// <copyright file="AssertionMessageBuilder.cs" company="On Test Automation">
 // Copyright 2019 the original author or authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,10 +16,10 @@
 namespace RestAssured.Response.Logging
 {
     using System.Collections.Generic;
-    using System.Runtime.CompilerServices;
     using Stubble.Core;
     using Stubble.Core.Builders;
     using Stubble.Core.Classes;
+    using Stubble.Core.Settings;
 
     /// <summary>
     /// Contains helper methods for logging assertion results.
@@ -65,7 +65,7 @@ namespace RestAssured.Response.Logging
                 .Configure(builder => builder.SetDefaultTags(new Tags(START_TAG, END_TAG)))
                 .Build();
 
-            return renderer.Render(originalMessage, values);
+            return renderer.Render(originalMessage, values, new RenderSettings { SkipHtmlEncoding = true });
         }
     }
 }

--- a/RestAssured.Net/Response/VerifiableResponse.cs
+++ b/RestAssured.Net/Response/VerifiableResponse.cs
@@ -407,7 +407,7 @@ namespace RestAssured.Response
         {
             this.RequireContentType(SupportedContentType.Json);
 
-            string responseBodyAsString = this.Response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            string responseBodyAsString = this.ReadBodyAsString();
 
             ICollection<ValidationError> schemaValidationErrors = jsonSchema.Validate(responseBodyAsString);
 
@@ -495,7 +495,7 @@ namespace RestAssured.Response
         /// <returns>The current <see cref="VerifiableResponse"/> object.</returns>
         public VerifiableResponse ResponseBodyLength(IMatcher<int> matcher, ErrorMessage errorMessage = default)
         {
-            string responseContentAsString = this.Response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            string responseContentAsString = this.ReadBodyAsString();
 
             if (!matcher.Matches(responseContentAsString.Length))
             {
@@ -585,7 +585,7 @@ namespace RestAssured.Response
         {
             this.RequireContentType(SupportedContentType.Xml);
 
-            string responseXmlAsString = this.Response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            string responseXmlAsString = this.ReadBodyAsString();
             XmlReader reader = XmlReader.Create(new StringReader(responseXmlAsString), settings);
 
             try
@@ -727,7 +727,7 @@ namespace RestAssured.Response
 
         private ResolvedBody ResolveBodyAndContentType(VerifyAs verifyAs)
         {
-            string body = this.Response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            string body = this.ReadBodyAsString();
             string mediaType = this.Response.Content.Headers.ContentType?.MediaType ?? string.Empty;
 
             try

--- a/RestAssured.Net/Response/VerifiableResponse.cs
+++ b/RestAssured.Net/Response/VerifiableResponse.cs
@@ -602,7 +602,9 @@ namespace RestAssured.Response
 
             if (resultingElement == null)
             {
-                this.FailVerification($"JsonPath expression '{nodePath.Expression}' did not yield any results.");
+                this.FailVerification(errorMessage.HasValue
+                    ? $"{errorMessage.Value!}: JsonPath expression '{nodePath.Expression}' did not yield any results."
+                    : $"JsonPath expression '{nodePath.Expression}' did not yield any results.");
             }
 
             T valueToMatch = resultingElement!.GetType().Equals(typeof(JArray))
@@ -652,7 +654,9 @@ namespace RestAssured.Response
             }
             catch (FormatException)
             {
-                this.FailVerification($"Response element value {innerText} cannot be converted to value of type '{typeof(T)}'");
+                this.FailVerification(errorMessage.HasValue
+                    ? $"{errorMessage.Value!}: Response element value {innerText} cannot be converted to value of type '{typeof(T)}'"
+                    : $"Response element value {innerText} cannot be converted to value of type '{typeof(T)}'");
             }
         }
 
@@ -669,7 +673,9 @@ namespace RestAssured.Response
                 }
                 catch (FormatException)
                 {
-                    this.FailVerification($"Response element value {innerText} cannot be converted to object of type {typeof(T)}");
+                    this.FailVerification(errorMessage.HasValue
+                        ? $"{errorMessage.Value!}: Response element value {innerText} cannot be converted to object of type {typeof(T)}"
+                        : $"Response element value {innerText} cannot be converted to object of type {typeof(T)}");
                 }
             }
 

--- a/RestAssured.Net/Response/VerifiableResponse.cs
+++ b/RestAssured.Net/Response/VerifiableResponse.cs
@@ -136,13 +136,7 @@ namespace RestAssured.Response
         /// <exception cref="ResponseVerificationException">Thrown when the actual status code does not match the expected one.</exception>
         public VerifiableResponse StatusCode(IMatcher<int> matcher, ErrorMessage errorMessage = default)
         {
-            if (!matcher.Matches((int)this.Response.StatusCode))
-            {
-                this.FailVerification(errorMessage.HasValue
-                    ? AssertionMessageBuilder.BuildMessage(errorMessage.Value!, matcher, (int)this.Response.StatusCode)
-                    : $"Expected response status code to match '{matcher}', but was {(int)this.Response.StatusCode}");
-            }
-
+            this.VerifyWithMatcher(matcher, (int)this.Response.StatusCode, $"Expected response status code to match '{matcher}', but was {(int)this.Response.StatusCode}", errorMessage);
             return this;
         }
 
@@ -155,13 +149,7 @@ namespace RestAssured.Response
         /// <exception cref="ResponseVerificationException">Thrown when the actual status code does not match the expected one.</exception>
         public VerifiableResponse StatusCode(IMatcher<HttpStatusCode> matcher, ErrorMessage errorMessage = default)
         {
-            if (!matcher.Matches(this.Response.StatusCode))
-            {
-                this.FailVerification(errorMessage.HasValue
-                    ? AssertionMessageBuilder.BuildMessage(errorMessage.Value!, matcher, this.Response.StatusCode)
-                    : $"Expected response status code to match '{matcher}', but was {this.Response.StatusCode}");
-            }
-
+            this.VerifyWithMatcher(matcher, this.Response.StatusCode, $"Expected response status code to match '{matcher}', but was {this.Response.StatusCode}", errorMessage);
             return this;
         }
 
@@ -326,19 +314,11 @@ namespace RestAssured.Response
         /// <returns>The current <see cref="VerifiableResponse"/> object.</returns>
         public VerifiableResponse Body<T>(string path, IMatcher<T> matcher, VerifyAs verifyAs = VerifyAs.UseResponseContentTypeHeaderValue, ErrorMessage errorMessage = default)
         {
-            ResolvedBody resolved = this.ResolveBodyAndContentType(verifyAs);
-            NodePath nodePath = new NodePath(path);
-
-            if (resolved.ContentType.Equals(SupportedContentType.Json))
-            {
-                this.VerifyJsonBody(nodePath, matcher, resolved, errorMessage);
-            }
-            else
-            {
-                this.VerifyMarkupBody(nodePath, matcher, resolved, errorMessage);
-            }
-
-            return this;
+            return this.DispatchBodyVerification(
+                path,
+                verifyAs,
+                (np, rb) => this.VerifyJsonBody(np, matcher, rb, errorMessage),
+                (np, rb) => this.VerifyMarkupBody(np, matcher, rb, errorMessage));
         }
 
         /// <summary>
@@ -352,19 +332,11 @@ namespace RestAssured.Response
         /// <returns>The current <see cref="VerifiableResponse"/> object.</returns>
         public VerifiableResponse Body<T>(string path, IMatcher<IEnumerable<T>> matcher, VerifyAs verifyAs = VerifyAs.UseResponseContentTypeHeaderValue, ErrorMessage errorMessage = default)
         {
-            ResolvedBody resolved = this.ResolveBodyAndContentType(verifyAs);
-            NodePath nodePath = new NodePath(path);
-
-            if (resolved.ContentType.Equals(SupportedContentType.Json))
-            {
-                this.VerifyJsonElements(nodePath, matcher, resolved, errorMessage);
-            }
-            else
-            {
-                this.VerifyMarkupElements(nodePath, matcher, resolved, errorMessage);
-            }
-
-            return this;
+            return this.DispatchBodyVerification(
+                path,
+                verifyAs,
+                (np, rb) => this.VerifyJsonElements(np, matcher, rb, errorMessage),
+                (np, rb) => this.VerifyMarkupElements(np, matcher, rb, errorMessage));
         }
 
         /// <summary>
@@ -473,13 +445,7 @@ namespace RestAssured.Response
         /// <returns>The current <see cref="VerifiableResponse"/> object.</returns>
         public VerifiableResponse ResponseTime(IMatcher<TimeSpan> matcher, ErrorMessage errorMessage = default)
         {
-            if (!matcher.Matches(this.ElapsedTime))
-            {
-                this.FailVerification(errorMessage.HasValue
-                    ? AssertionMessageBuilder.BuildMessage(errorMessage.Value!, matcher, this.ElapsedTime)
-                    : $"Expected response time to match '{matcher}' but was '{this.ElapsedTime}'");
-            }
-
+            this.VerifyWithMatcher(matcher, this.ElapsedTime, $"Expected response time to match '{matcher}' but was '{this.ElapsedTime}'", errorMessage);
             return this;
         }
 
@@ -764,6 +730,33 @@ namespace RestAssured.Response
         private string ReadBodyAsString()
         {
             return this.Response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+        }
+
+        private void VerifyWithMatcher<T>(IMatcher<T> matcher, T actualValue, string defaultMessage, ErrorMessage errorMessage)
+        {
+            if (!matcher.Matches(actualValue))
+            {
+                this.FailVerification(errorMessage.HasValue
+                    ? AssertionMessageBuilder.BuildMessage(errorMessage.Value!, matcher, actualValue!)
+                    : defaultMessage);
+            }
+        }
+
+        private VerifiableResponse DispatchBodyVerification(string path, VerifyAs verifyAs, Action<NodePath, ResolvedBody> jsonVerify, Action<NodePath, ResolvedBody> markupVerify)
+        {
+            ResolvedBody resolved = this.ResolveBodyAndContentType(verifyAs);
+            NodePath nodePath = new NodePath(path);
+
+            if (resolved.ContentType.Equals(SupportedContentType.Json))
+            {
+                jsonVerify(nodePath, resolved);
+            }
+            else
+            {
+                markupVerify(nodePath, resolved);
+            }
+
+            return this;
         }
 
         private void FailVerification(string exceptionMessage)

--- a/RestAssured.Net/Response/VerifiableResponse.cs
+++ b/RestAssured.Net/Response/VerifiableResponse.cs
@@ -170,11 +170,12 @@ namespace RestAssured.Response
         /// </summary>
         /// <param name="name">The expected response header name.</param>
         /// <param name="expectedValue">The corresponding expected response header value.</param>
+        /// <param name="errorMessage">A custom error message to be used when the verification fails.</param>
         /// <returns>The current <see cref="VerifiableResponse"/> object.</returns>
         /// <exception cref="ResponseVerificationException">Thrown when the header does not exist, or when the header value does not equal the supplied expected value.</exception>
-        public VerifiableResponse Header(string name, string expectedValue)
+        public VerifiableResponse Header(string name, string expectedValue, string? errorMessage = null)
         {
-            return this.Header(name, Is.EqualTo(expectedValue));
+            return this.Header(name, Is.EqualTo(expectedValue), errorMessage);
         }
 
         /// <summary>
@@ -182,9 +183,10 @@ namespace RestAssured.Response
         /// </summary>
         /// <param name="name">The expected response header name.</param>
         /// <param name="matcher">The NHamcrest matcher to evaluate.</param>
+        /// <param name="errorMessage">A custom error message to be used when the verification fails.</param>
         /// <returns>The current <see cref="VerifiableResponse"/> object.</returns>
         /// <exception cref="ResponseVerificationException">Thrown when the header does not exist, or when the header value does not equal the supplied expected value.</exception>
-        public VerifiableResponse Header(string name, IMatcher<string> matcher)
+        public VerifiableResponse Header(string name, IMatcher<string> matcher, string? errorMessage = null)
         {
             if (this.Response.Headers.TryGetValues(name, out IEnumerable<string>? values))
             {
@@ -192,12 +194,14 @@ namespace RestAssured.Response
 
                 if (!matcher.Matches(firstValue))
                 {
-                    this.FailVerification($"Expected value for response header with name '{name}' to match '{matcher}', but was '{firstValue}'.");
+                    this.FailVerification(errorMessage != null
+                        ? AssertionMessageBuilder.BuildMessage(errorMessage, matcher, firstValue)
+                        : $"Expected value for response header with name '{name}' to match '{matcher}', but was '{firstValue}'.");
                 }
             }
             else
             {
-                this.FailVerification($"Expected header with name '{name}' to be in the response, but it could not be found.");
+                this.FailVerification(errorMessage ?? $"Expected header with name '{name}' to be in the response, but it could not be found.");
             }
 
             return this;
@@ -207,31 +211,35 @@ namespace RestAssured.Response
         /// Verifies that the response Content-Type header has the expected value.
         /// </summary>
         /// <param name="expectedContentType">The expected value for the response Content-Type header.</param>
+        /// <param name="errorMessage">A custom error message to be used when the verification fails.</param>
         /// <returns>The current <see cref="VerifiableResponse"/> object.</returns>
         /// <exception cref="ResponseVerificationException">Thrown when the "Content-Type" header does not exist, or when the header value does not equal the supplied expected value.</exception>
-        public VerifiableResponse ContentType(string expectedContentType)
+        public VerifiableResponse ContentType(string expectedContentType, string? errorMessage = null)
         {
-            return this.ContentType(Is.EqualTo(expectedContentType));
+            return this.ContentType(Is.EqualTo(expectedContentType), errorMessage);
         }
 
         /// <summary>
         /// Verifies that the response Content-Type header value matches a given NHamcrest matcher.
         /// </summary>
         /// <param name="matcher">The NHamcrest matcher to evaluate.</param>
+        /// <param name="errorMessage">A custom error message to be used when the verification fails.</param>
         /// <returns>The current <see cref="VerifiableResponse"/> object.</returns>
         /// <exception cref="ResponseVerificationException">Thrown when the "Content-Type" header does not exist, or when the header value does not equal the supplied expected value.</exception>
-        public VerifiableResponse ContentType(IMatcher<string> matcher)
+        public VerifiableResponse ContentType(IMatcher<string> matcher, string? errorMessage = null)
         {
             MediaTypeHeaderValue? actualContentType = this.Response.Content.Headers.ContentType;
 
             if (actualContentType == null)
             {
-                this.FailVerification("Response Content-Type header could not be found.");
+                this.FailVerification(errorMessage ?? "Response Content-Type header could not be found.");
             }
 
             if (!matcher.Matches(actualContentType!.ToString()))
             {
-                this.FailVerification($"Expected value for response Content-Type header to match '{matcher}', but was '{actualContentType}'.");
+                this.FailVerification(errorMessage != null
+                    ? AssertionMessageBuilder.BuildMessage(errorMessage, matcher, actualContentType.ToString())
+                    : $"Expected value for response Content-Type header to match '{matcher}', but was '{actualContentType}'.");
             }
 
             return this;
@@ -242,8 +250,9 @@ namespace RestAssured.Response
         /// </summary>
         /// <param name="name">The name of the cookie to verify.</param>
         /// <param name="matcher">The NHamcrest matcher to evaluate.</param>
+        /// <param name="errorMessage">A custom error message to be used when the verification fails.</param>
         /// <returns>The current <see cref="VerifiableResponse"/> object.</returns>
-        public VerifiableResponse Cookie(string name, IMatcher<string> matcher)
+        public VerifiableResponse Cookie(string name, IMatcher<string> matcher, string? errorMessage = null)
         {
             var cookies = this.CookieContainer.GetAllCookies().GetEnumerator();
 
@@ -254,14 +263,16 @@ namespace RestAssured.Response
                 {
                     if (!matcher.Matches(cookie.Value))
                     {
-                        this.FailVerification($"Expected value for cookie with name '{name}' to match '{matcher}', but was '{cookie.Value}'.");
+                        this.FailVerification(errorMessage != null
+                            ? AssertionMessageBuilder.BuildMessage(errorMessage, matcher, cookie.Value)
+                            : $"Expected value for cookie with name '{name}' to match '{matcher}', but was '{cookie.Value}'.");
                     }
 
                     return this;
                 }
             }
 
-            this.FailVerification($"Cookie with name '{name}' could not be found in the response.");
+            this.FailVerification(errorMessage ?? $"Cookie with name '{name}' could not be found in the response.");
 
             return this;
         }
@@ -270,15 +281,18 @@ namespace RestAssured.Response
         /// Verifies that the response body is equal to the specified expected body.
         /// </summary>
         /// <param name="expectedResponseBody">The expected response body.</param>
+        /// <param name="errorMessage">A custom error message to be used when the verification fails.</param>
         /// <returns>The current <see cref="VerifiableResponse"/> object.</returns>
         /// <exception cref="ResponseVerificationException">Thrown when the actual response body does not match the expected one.</exception>
-        public VerifiableResponse Body(string expectedResponseBody)
+        public VerifiableResponse Body(string expectedResponseBody, string? errorMessage = null)
         {
             string actualResponseBody = this.Response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
 
             if (!actualResponseBody.Equals(expectedResponseBody))
             {
-                this.FailVerification($"Actual response body did not match expected response body.\nExpected: '{expectedResponseBody}'\nActual: '{actualResponseBody}'");
+                this.FailVerification(errorMessage != null
+                    ? AssertionMessageBuilder.BuildMessage(errorMessage, expectedResponseBody, actualResponseBody)
+                    : $"Actual response body did not match expected response body.\nExpected: '{expectedResponseBody}'\nActual: '{actualResponseBody}'");
             }
 
             return this;
@@ -288,15 +302,18 @@ namespace RestAssured.Response
         /// Verifies that the response body matches the specified NHamcrest matcher.
         /// </summary>
         /// <param name="matcher">The NHamcrest matcher to evaluate.</param>
+        /// <param name="errorMessage">A custom error message to be used when the verification fails.</param>
         /// <returns>The current <see cref="VerifiableResponse"/> object.</returns>
         /// <exception cref="ResponseVerificationException">Thrown when the actual response body does not match the expected one.</exception>
-        public VerifiableResponse Body(IMatcher<string> matcher)
+        public VerifiableResponse Body(IMatcher<string> matcher, string? errorMessage = null)
         {
             string actualResponseBody = this.Response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
 
             if (!matcher.Matches(actualResponseBody))
             {
-                this.FailVerification($"Actual response body expected to match '{matcher}' but didn't.\nActual: '{actualResponseBody}'");
+                this.FailVerification(errorMessage != null
+                    ? AssertionMessageBuilder.BuildMessage(errorMessage, matcher, actualResponseBody)
+                    : $"Actual response body expected to match '{matcher}' but didn't.\nActual: '{actualResponseBody}'");
             }
 
             return this;
@@ -309,19 +326,20 @@ namespace RestAssured.Response
         /// <param name="path">The JsonPath or XPath expression to evaluate.</param>
         /// <param name="matcher">The NHamcrest matcher to evaluate.</param>
         /// <param name="verifyAs">Indicates how to interpret the response.</param>
+        /// <param name="errorMessage">A custom error message to be used when the verification fails.</param>
         /// <returns>The current <see cref="VerifiableResponse"/> object.</returns>
-        public VerifiableResponse Body<T>(string path, IMatcher<T> matcher, VerifyAs verifyAs = VerifyAs.UseResponseContentTypeHeaderValue)
+        public VerifiableResponse Body<T>(string path, IMatcher<T> matcher, VerifyAs verifyAs = VerifyAs.UseResponseContentTypeHeaderValue, string? errorMessage = null)
         {
             ResolvedBody resolved = this.ResolveBodyAndContentType(verifyAs);
             NodePath nodePath = new NodePath(path);
 
             if (resolved.ContentType.Equals(SupportedContentType.Json))
             {
-                this.VerifyJsonBody(nodePath, matcher, resolved);
+                this.VerifyJsonBody(nodePath, matcher, resolved, errorMessage);
             }
             else
             {
-                this.VerifyMarkupBody(nodePath, matcher, resolved);
+                this.VerifyMarkupBody(nodePath, matcher, resolved, errorMessage);
             }
 
             return this;
@@ -334,19 +352,20 @@ namespace RestAssured.Response
         /// <param name="path">The JsonPath expression to evaluate.</param>
         /// <param name="matcher">The NHamcrest matcher to evaluate.</param>
         /// <param name="verifyAs">Indicates how to interpret the response.</param>
+        /// <param name="errorMessage">A custom error message to be used when the verification fails.</param>
         /// <returns>The current <see cref="VerifiableResponse"/> object.</returns>
-        public VerifiableResponse Body<T>(string path, IMatcher<IEnumerable<T>> matcher, VerifyAs verifyAs = VerifyAs.UseResponseContentTypeHeaderValue)
+        public VerifiableResponse Body<T>(string path, IMatcher<IEnumerable<T>> matcher, VerifyAs verifyAs = VerifyAs.UseResponseContentTypeHeaderValue, string? errorMessage = null)
         {
             ResolvedBody resolved = this.ResolveBodyAndContentType(verifyAs);
             NodePath nodePath = new NodePath(path);
 
             if (resolved.ContentType.Equals(SupportedContentType.Json))
             {
-                this.VerifyJsonElements(nodePath, matcher, resolved);
+                this.VerifyJsonElements(nodePath, matcher, resolved, errorMessage);
             }
             else
             {
-                this.VerifyMarkupElements(nodePath, matcher, resolved);
+                this.VerifyMarkupElements(nodePath, matcher, resolved, errorMessage);
             }
 
             return this;
@@ -454,12 +473,15 @@ namespace RestAssured.Response
         /// Verifies that the response time matches the specified NHamcrest matcher.
         /// </summary>
         /// <param name="matcher">The NHamcrest matcher to match against the response time.</param>
+        /// <param name="errorMessage">A custom error message to be used when the verification fails.</param>
         /// <returns>The current <see cref="VerifiableResponse"/> object.</returns>
-        public VerifiableResponse ResponseTime(IMatcher<TimeSpan> matcher)
+        public VerifiableResponse ResponseTime(IMatcher<TimeSpan> matcher, string? errorMessage = null)
         {
             if (!matcher.Matches(this.ElapsedTime))
             {
-                this.FailVerification($"Expected response time to match '{matcher}' but was '{this.ElapsedTime}'");
+                this.FailVerification(errorMessage != null
+                    ? AssertionMessageBuilder.BuildMessage(errorMessage, matcher, this.ElapsedTime)
+                    : $"Expected response time to match '{matcher}' but was '{this.ElapsedTime}'");
             }
 
             return this;
@@ -469,14 +491,17 @@ namespace RestAssured.Response
         /// Verifies that the response body length (in bytes) matches the specified NHamcrest matcher.
         /// </summary>
         /// <param name="matcher">The NHamcrest matcher to match against the response body length (in bytes).</param>
+        /// <param name="errorMessage">A custom error message to be used when the verification fails.</param>
         /// <returns>The current <see cref="VerifiableResponse"/> object.</returns>
-        public VerifiableResponse ResponseBodyLength(IMatcher<int> matcher)
+        public VerifiableResponse ResponseBodyLength(IMatcher<int> matcher, string? errorMessage = null)
         {
             string responseContentAsString = this.Response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
 
             if (!matcher.Matches(responseContentAsString.Length))
             {
-                this.FailVerification($"Expected response body length to match '{matcher}' but was '{responseContentAsString.Length}'");
+                this.FailVerification(errorMessage != null
+                    ? AssertionMessageBuilder.BuildMessage(errorMessage, matcher, responseContentAsString.Length)
+                    : $"Expected response body length to match '{matcher}' but was '{responseContentAsString.Length}'");
             }
 
             return this;
@@ -575,7 +600,7 @@ namespace RestAssured.Response
             }
         }
 
-        private void VerifyJsonBody<T>(NodePath nodePath, IMatcher<T> matcher, ResolvedBody resolved)
+        private void VerifyJsonBody<T>(NodePath nodePath, IMatcher<T> matcher, ResolvedBody resolved, string? errorMessage = null)
         {
             JToken? resultingElement = JToken.Parse(resolved.Content).SelectToken(nodePath.Expression);
 
@@ -590,11 +615,13 @@ namespace RestAssured.Response
 
             if (!matcher.Matches(valueToMatch))
             {
-                this.FailVerification($"Expected element selected by '{nodePath.Expression}' to match '{matcher}' but was '{resultingElement}'");
+                this.FailVerification(errorMessage != null
+                    ? AssertionMessageBuilder.BuildMessage(errorMessage, matcher, resultingElement!)
+                    : $"Expected element selected by '{nodePath.Expression}' to match '{matcher}' but was '{resultingElement}'");
             }
         }
 
-        private void VerifyJsonElements<T>(NodePath nodePath, IMatcher<IEnumerable<T>> matcher, ResolvedBody resolved)
+        private void VerifyJsonElements<T>(NodePath nodePath, IMatcher<IEnumerable<T>> matcher, ResolvedBody resolved, string? errorMessage = null)
         {
             List<T> elementValues = new List<T>();
 
@@ -607,11 +634,13 @@ namespace RestAssured.Response
 
             if (!matcher.Matches(elementValues))
             {
-                this.FailVerification($"Expected elements selected by '{nodePath.Expression}' to match '{matcher}', but was [{string.Join(", ", elementValues)}]");
+                this.FailVerification(errorMessage != null
+                    ? AssertionMessageBuilder.BuildMessage(errorMessage, matcher, string.Join(", ", elementValues))
+                    : $"Expected elements selected by '{nodePath.Expression}' to match '{matcher}', but was [{string.Join(", ", elementValues)}]");
             }
         }
 
-        private void VerifyMarkupBody<T>(NodePath nodePath, IMatcher<T> matcher, ResolvedBody resolved)
+        private void VerifyMarkupBody<T>(NodePath nodePath, IMatcher<T> matcher, ResolvedBody resolved, string? errorMessage = null)
         {
             string innerText = this.SelectSingleNodeInnerText(nodePath, resolved);
 
@@ -620,7 +649,9 @@ namespace RestAssured.Response
             {
                 if (!matcher.Matches((T)Convert.ChangeType(innerText, typeof(T))))
                 {
-                    this.FailVerification($"Expected element selected by '{nodePath.Expression}' to match '{matcher}' but was '{innerText}'");
+                    this.FailVerification(errorMessage != null
+                        ? AssertionMessageBuilder.BuildMessage(errorMessage, matcher, innerText)
+                        : $"Expected element selected by '{nodePath.Expression}' to match '{matcher}' but was '{innerText}'");
                 }
             }
             catch (FormatException)
@@ -629,7 +660,7 @@ namespace RestAssured.Response
             }
         }
 
-        private void VerifyMarkupElements<T>(NodePath nodePath, IMatcher<IEnumerable<T>> matcher, ResolvedBody resolved)
+        private void VerifyMarkupElements<T>(NodePath nodePath, IMatcher<IEnumerable<T>> matcher, ResolvedBody resolved, string? errorMessage = null)
         {
             List<T> elementValues = new List<T>();
 
@@ -648,7 +679,9 @@ namespace RestAssured.Response
 
             if (!matcher.Matches(elementValues))
             {
-                this.FailVerification($"Expected elements selected by '{nodePath.Expression}' to match '{matcher}', but was [{string.Join(", ", elementValues)}]");
+                this.FailVerification(errorMessage != null
+                    ? AssertionMessageBuilder.BuildMessage(errorMessage, matcher, string.Join(", ", elementValues))
+                    : $"Expected elements selected by '{nodePath.Expression}' to match '{matcher}', but was [{string.Join(", ", elementValues)}]");
             }
         }
 

--- a/RestAssured.Net/Response/VerifiableResponse.cs
+++ b/RestAssured.Net/Response/VerifiableResponse.cs
@@ -110,7 +110,7 @@ namespace RestAssured.Response
         /// <param name="errorMessage">A custom error message to be used when the verification fails.</param>
         /// <returns>The current <see cref="VerifiableResponse"/> object.</returns>
         /// <exception cref="ResponseVerificationException">Thrown when the actual status code does not match the expected one.</exception>
-        public VerifiableResponse StatusCode(int expectedStatusCode, string? errorMessage = null)
+        public VerifiableResponse StatusCode(int expectedStatusCode, ErrorMessage errorMessage = default)
         {
             return this.StatusCode(Is.EqualTo(expectedStatusCode), errorMessage);
         }
@@ -122,7 +122,7 @@ namespace RestAssured.Response
         /// <param name="errorMessage">A custom error message to be used when the verification fails.</param>
         /// <returns>The current <see cref="VerifiableResponse"/> object.</returns>
         /// <exception cref="ResponseVerificationException">Thrown when the actual status code does not match the expected one.</exception>
-        public VerifiableResponse StatusCode(HttpStatusCode expectedStatusCode, string? errorMessage = null)
+        public VerifiableResponse StatusCode(HttpStatusCode expectedStatusCode, ErrorMessage errorMessage = default)
         {
             return this.StatusCode(Is.EqualTo(expectedStatusCode), errorMessage);
         }
@@ -134,13 +134,15 @@ namespace RestAssured.Response
         /// <param name="errorMessage">A custom error message to be used when the verification fails.</param>
         /// <returns>The current <see cref="VerifiableResponse"/> object.</returns>
         /// <exception cref="ResponseVerificationException">Thrown when the actual status code does not match the expected one.</exception>
-        public VerifiableResponse StatusCode(IMatcher<int> matcher, string? errorMessage = null)
+        public VerifiableResponse StatusCode(IMatcher<int> matcher, ErrorMessage errorMessage = default)
         {
             if (!matcher.Matches((int)this.Response.StatusCode))
             {
-                errorMessage ??= $"Expected response status code to match '{matcher}', but was {(int)this.Response.StatusCode}";
+                string message = errorMessage.HasValue
+                    ? errorMessage.Value!
+                    : $"Expected response status code to match '{matcher}', but was {(int)this.Response.StatusCode}";
 
-                this.FailVerification(AssertionMessageBuilder.BuildMessage(errorMessage, matcher, (int)this.Response.StatusCode));
+                this.FailVerification(AssertionMessageBuilder.BuildMessage(message, matcher, (int)this.Response.StatusCode));
             }
 
             return this;
@@ -153,13 +155,15 @@ namespace RestAssured.Response
         /// <param name="errorMessage">A custom error message to be used when the verification fails.</param>
         /// <returns>The current <see cref="VerifiableResponse"/> object.</returns>
         /// <exception cref="ResponseVerificationException">Thrown when the actual status code does not match the expected one.</exception>
-        public VerifiableResponse StatusCode(IMatcher<HttpStatusCode> matcher, string? errorMessage = null)
+        public VerifiableResponse StatusCode(IMatcher<HttpStatusCode> matcher, ErrorMessage errorMessage = default)
         {
             if (!matcher.Matches(this.Response.StatusCode))
             {
-                errorMessage ??= $"Expected response status code to match '{matcher}', but was {this.Response.StatusCode}";
+                string message = errorMessage.HasValue
+                    ? errorMessage.Value!
+                    : $"Expected response status code to match '{matcher}', but was {this.Response.StatusCode}";
 
-                this.FailVerification(AssertionMessageBuilder.BuildMessage(errorMessage, matcher, this.Response.StatusCode));
+                this.FailVerification(AssertionMessageBuilder.BuildMessage(message, matcher, this.Response.StatusCode));
             }
 
             return this;
@@ -173,7 +177,7 @@ namespace RestAssured.Response
         /// <param name="errorMessage">A custom error message to be used when the verification fails.</param>
         /// <returns>The current <see cref="VerifiableResponse"/> object.</returns>
         /// <exception cref="ResponseVerificationException">Thrown when the header does not exist, or when the header value does not equal the supplied expected value.</exception>
-        public VerifiableResponse Header(string name, string expectedValue, string? errorMessage = null)
+        public VerifiableResponse Header(string name, string expectedValue, ErrorMessage errorMessage = default)
         {
             return this.Header(name, Is.EqualTo(expectedValue), errorMessage);
         }
@@ -186,7 +190,7 @@ namespace RestAssured.Response
         /// <param name="errorMessage">A custom error message to be used when the verification fails.</param>
         /// <returns>The current <see cref="VerifiableResponse"/> object.</returns>
         /// <exception cref="ResponseVerificationException">Thrown when the header does not exist, or when the header value does not equal the supplied expected value.</exception>
-        public VerifiableResponse Header(string name, IMatcher<string> matcher, string? errorMessage = null)
+        public VerifiableResponse Header(string name, IMatcher<string> matcher, ErrorMessage errorMessage = default)
         {
             if (this.Response.Headers.TryGetValues(name, out IEnumerable<string>? values))
             {
@@ -194,14 +198,16 @@ namespace RestAssured.Response
 
                 if (!matcher.Matches(firstValue))
                 {
-                    this.FailVerification(errorMessage != null
-                        ? AssertionMessageBuilder.BuildMessage(errorMessage, matcher, firstValue)
+                    this.FailVerification(errorMessage.HasValue
+                        ? AssertionMessageBuilder.BuildMessage(errorMessage.Value!, matcher, firstValue)
                         : $"Expected value for response header with name '{name}' to match '{matcher}', but was '{firstValue}'.");
                 }
             }
             else
             {
-                this.FailVerification(errorMessage ?? $"Expected header with name '{name}' to be in the response, but it could not be found.");
+                this.FailVerification(errorMessage.HasValue
+                    ? errorMessage.Value!
+                    : $"Expected header with name '{name}' to be in the response, but it could not be found.");
             }
 
             return this;
@@ -214,7 +220,7 @@ namespace RestAssured.Response
         /// <param name="errorMessage">A custom error message to be used when the verification fails.</param>
         /// <returns>The current <see cref="VerifiableResponse"/> object.</returns>
         /// <exception cref="ResponseVerificationException">Thrown when the "Content-Type" header does not exist, or when the header value does not equal the supplied expected value.</exception>
-        public VerifiableResponse ContentType(string expectedContentType, string? errorMessage = null)
+        public VerifiableResponse ContentType(string expectedContentType, ErrorMessage errorMessage = default)
         {
             return this.ContentType(Is.EqualTo(expectedContentType), errorMessage);
         }
@@ -226,19 +232,21 @@ namespace RestAssured.Response
         /// <param name="errorMessage">A custom error message to be used when the verification fails.</param>
         /// <returns>The current <see cref="VerifiableResponse"/> object.</returns>
         /// <exception cref="ResponseVerificationException">Thrown when the "Content-Type" header does not exist, or when the header value does not equal the supplied expected value.</exception>
-        public VerifiableResponse ContentType(IMatcher<string> matcher, string? errorMessage = null)
+        public VerifiableResponse ContentType(IMatcher<string> matcher, ErrorMessage errorMessage = default)
         {
             MediaTypeHeaderValue? actualContentType = this.Response.Content.Headers.ContentType;
 
             if (actualContentType == null)
             {
-                this.FailVerification(errorMessage ?? "Response Content-Type header could not be found.");
+                this.FailVerification(errorMessage.HasValue
+                    ? errorMessage.Value!
+                    : "Response Content-Type header could not be found.");
             }
 
             if (!matcher.Matches(actualContentType!.ToString()))
             {
-                this.FailVerification(errorMessage != null
-                    ? AssertionMessageBuilder.BuildMessage(errorMessage, matcher, actualContentType.ToString())
+                this.FailVerification(errorMessage.HasValue
+                    ? AssertionMessageBuilder.BuildMessage(errorMessage.Value!, matcher, actualContentType.ToString())
                     : $"Expected value for response Content-Type header to match '{matcher}', but was '{actualContentType}'.");
             }
 
@@ -252,7 +260,7 @@ namespace RestAssured.Response
         /// <param name="matcher">The NHamcrest matcher to evaluate.</param>
         /// <param name="errorMessage">A custom error message to be used when the verification fails.</param>
         /// <returns>The current <see cref="VerifiableResponse"/> object.</returns>
-        public VerifiableResponse Cookie(string name, IMatcher<string> matcher, string? errorMessage = null)
+        public VerifiableResponse Cookie(string name, IMatcher<string> matcher, ErrorMessage errorMessage = default)
         {
             var cookies = this.CookieContainer.GetAllCookies().GetEnumerator();
 
@@ -263,8 +271,8 @@ namespace RestAssured.Response
                 {
                     if (!matcher.Matches(cookie.Value))
                     {
-                        this.FailVerification(errorMessage != null
-                            ? AssertionMessageBuilder.BuildMessage(errorMessage, matcher, cookie.Value)
+                        this.FailVerification(errorMessage.HasValue
+                            ? AssertionMessageBuilder.BuildMessage(errorMessage.Value!, matcher, cookie.Value)
                             : $"Expected value for cookie with name '{name}' to match '{matcher}', but was '{cookie.Value}'.");
                     }
 
@@ -272,7 +280,9 @@ namespace RestAssured.Response
                 }
             }
 
-            this.FailVerification(errorMessage ?? $"Cookie with name '{name}' could not be found in the response.");
+            this.FailVerification(errorMessage.HasValue
+                ? errorMessage.Value!
+                : $"Cookie with name '{name}' could not be found in the response.");
 
             return this;
         }
@@ -284,7 +294,7 @@ namespace RestAssured.Response
         /// <param name="errorMessage">A custom error message to be used when the verification fails.</param>
         /// <returns>The current <see cref="VerifiableResponse"/> object.</returns>
         /// <exception cref="ResponseVerificationException">Thrown when the actual response body does not match the expected one.</exception>
-        public VerifiableResponse Body(string expectedResponseBody, string? errorMessage = null)
+        public VerifiableResponse Body(string expectedResponseBody, ErrorMessage errorMessage = default)
         {
             return this.VerifyResponseBody(
                 actual => !actual.Equals(expectedResponseBody),
@@ -300,7 +310,7 @@ namespace RestAssured.Response
         /// <param name="errorMessage">A custom error message to be used when the verification fails.</param>
         /// <returns>The current <see cref="VerifiableResponse"/> object.</returns>
         /// <exception cref="ResponseVerificationException">Thrown when the actual response body does not match the expected one.</exception>
-        public VerifiableResponse Body(IMatcher<string> matcher, string? errorMessage = null)
+        public VerifiableResponse Body(IMatcher<string> matcher, ErrorMessage errorMessage = default)
         {
             return this.VerifyResponseBody(
                 actual => !matcher.Matches(actual),
@@ -318,7 +328,7 @@ namespace RestAssured.Response
         /// <param name="verifyAs">Indicates how to interpret the response.</param>
         /// <param name="errorMessage">A custom error message to be used when the verification fails.</param>
         /// <returns>The current <see cref="VerifiableResponse"/> object.</returns>
-        public VerifiableResponse Body<T>(string path, IMatcher<T> matcher, VerifyAs verifyAs = VerifyAs.UseResponseContentTypeHeaderValue, string? errorMessage = null)
+        public VerifiableResponse Body<T>(string path, IMatcher<T> matcher, VerifyAs verifyAs = VerifyAs.UseResponseContentTypeHeaderValue, ErrorMessage errorMessage = default)
         {
             ResolvedBody resolved = this.ResolveBodyAndContentType(verifyAs);
             NodePath nodePath = new NodePath(path);
@@ -344,7 +354,7 @@ namespace RestAssured.Response
         /// <param name="verifyAs">Indicates how to interpret the response.</param>
         /// <param name="errorMessage">A custom error message to be used when the verification fails.</param>
         /// <returns>The current <see cref="VerifiableResponse"/> object.</returns>
-        public VerifiableResponse Body<T>(string path, IMatcher<IEnumerable<T>> matcher, VerifyAs verifyAs = VerifyAs.UseResponseContentTypeHeaderValue, string? errorMessage = null)
+        public VerifiableResponse Body<T>(string path, IMatcher<IEnumerable<T>> matcher, VerifyAs verifyAs = VerifyAs.UseResponseContentTypeHeaderValue, ErrorMessage errorMessage = default)
         {
             ResolvedBody resolved = this.ResolveBodyAndContentType(verifyAs);
             NodePath nodePath = new NodePath(path);
@@ -465,12 +475,12 @@ namespace RestAssured.Response
         /// <param name="matcher">The NHamcrest matcher to match against the response time.</param>
         /// <param name="errorMessage">A custom error message to be used when the verification fails.</param>
         /// <returns>The current <see cref="VerifiableResponse"/> object.</returns>
-        public VerifiableResponse ResponseTime(IMatcher<TimeSpan> matcher, string? errorMessage = null)
+        public VerifiableResponse ResponseTime(IMatcher<TimeSpan> matcher, ErrorMessage errorMessage = default)
         {
             if (!matcher.Matches(this.ElapsedTime))
             {
-                this.FailVerification(errorMessage != null
-                    ? AssertionMessageBuilder.BuildMessage(errorMessage, matcher, this.ElapsedTime)
+                this.FailVerification(errorMessage.HasValue
+                    ? AssertionMessageBuilder.BuildMessage(errorMessage.Value!, matcher, this.ElapsedTime)
                     : $"Expected response time to match '{matcher}' but was '{this.ElapsedTime}'");
             }
 
@@ -483,14 +493,14 @@ namespace RestAssured.Response
         /// <param name="matcher">The NHamcrest matcher to match against the response body length (in bytes).</param>
         /// <param name="errorMessage">A custom error message to be used when the verification fails.</param>
         /// <returns>The current <see cref="VerifiableResponse"/> object.</returns>
-        public VerifiableResponse ResponseBodyLength(IMatcher<int> matcher, string? errorMessage = null)
+        public VerifiableResponse ResponseBodyLength(IMatcher<int> matcher, ErrorMessage errorMessage = default)
         {
             string responseContentAsString = this.Response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
 
             if (!matcher.Matches(responseContentAsString.Length))
             {
-                this.FailVerification(errorMessage != null
-                    ? AssertionMessageBuilder.BuildMessage(errorMessage, matcher, responseContentAsString.Length)
+                this.FailVerification(errorMessage.HasValue
+                    ? AssertionMessageBuilder.BuildMessage(errorMessage.Value!, matcher, responseContentAsString.Length)
                     : $"Expected response body length to match '{matcher}' but was '{responseContentAsString.Length}'");
             }
 
@@ -734,13 +744,6 @@ namespace RestAssured.Response
         private readonly record struct ResolvedBody(string Content, SupportedContentType ContentType);
 
         private readonly record struct NodePath(string Expression);
-
-        private readonly record struct ErrorMessage(string? Value)
-        {
-            public bool HasValue => this.Value != null;
-
-            public static implicit operator ErrorMessage(string? value) => new ErrorMessage(value);
-        }
 
         private VerifiableResponse VerifyResponseBody(Func<string, bool> failCondition, Func<string, string> buildDefaultMessage, object expectedValue, ErrorMessage errorMessage)
         {

--- a/RestAssured.Net/Response/VerifiableResponse.cs
+++ b/RestAssured.Net/Response/VerifiableResponse.cs
@@ -138,11 +138,9 @@ namespace RestAssured.Response
         {
             if (!matcher.Matches((int)this.Response.StatusCode))
             {
-                string message = errorMessage.HasValue
-                    ? errorMessage.Value!
-                    : $"Expected response status code to match '{matcher}', but was {(int)this.Response.StatusCode}";
-
-                this.FailVerification(AssertionMessageBuilder.BuildMessage(message, matcher, (int)this.Response.StatusCode));
+                this.FailVerification(errorMessage.HasValue
+                    ? AssertionMessageBuilder.BuildMessage(errorMessage.Value!, matcher, (int)this.Response.StatusCode)
+                    : $"Expected response status code to match '{matcher}', but was {(int)this.Response.StatusCode}");
             }
 
             return this;
@@ -159,11 +157,9 @@ namespace RestAssured.Response
         {
             if (!matcher.Matches(this.Response.StatusCode))
             {
-                string message = errorMessage.HasValue
-                    ? errorMessage.Value!
-                    : $"Expected response status code to match '{matcher}', but was {this.Response.StatusCode}";
-
-                this.FailVerification(AssertionMessageBuilder.BuildMessage(message, matcher, this.Response.StatusCode));
+                this.FailVerification(errorMessage.HasValue
+                    ? AssertionMessageBuilder.BuildMessage(errorMessage.Value!, matcher, this.Response.StatusCode)
+                    : $"Expected response status code to match '{matcher}', but was {this.Response.StatusCode}");
             }
 
             return this;

--- a/RestAssured.Net/Response/VerifiableResponse.cs
+++ b/RestAssured.Net/Response/VerifiableResponse.cs
@@ -286,16 +286,11 @@ namespace RestAssured.Response
         /// <exception cref="ResponseVerificationException">Thrown when the actual response body does not match the expected one.</exception>
         public VerifiableResponse Body(string expectedResponseBody, string? errorMessage = null)
         {
-            string actualResponseBody = this.ReadBodyAsString();
-
-            if (!actualResponseBody.Equals(expectedResponseBody))
-            {
-                this.FailVerification(errorMessage != null
-                    ? AssertionMessageBuilder.BuildMessage(errorMessage, expectedResponseBody, actualResponseBody)
-                    : $"Actual response body did not match expected response body.\nExpected: '{expectedResponseBody}'\nActual: '{actualResponseBody}'");
-            }
-
-            return this;
+            return this.VerifyResponseBody(
+                actual => !actual.Equals(expectedResponseBody),
+                actual => $"Actual response body did not match expected response body.\nExpected: '{expectedResponseBody}'\nActual: '{actual}'",
+                expectedResponseBody,
+                errorMessage);
         }
 
         /// <summary>
@@ -307,16 +302,11 @@ namespace RestAssured.Response
         /// <exception cref="ResponseVerificationException">Thrown when the actual response body does not match the expected one.</exception>
         public VerifiableResponse Body(IMatcher<string> matcher, string? errorMessage = null)
         {
-            string actualResponseBody = this.ReadBodyAsString();
-
-            if (!matcher.Matches(actualResponseBody))
-            {
-                this.FailVerification(errorMessage != null
-                    ? AssertionMessageBuilder.BuildMessage(errorMessage, matcher, actualResponseBody)
-                    : $"Actual response body expected to match '{matcher}' but didn't.\nActual: '{actualResponseBody}'");
-            }
-
-            return this;
+            return this.VerifyResponseBody(
+                actual => !matcher.Matches(actual),
+                actual => $"Actual response body expected to match '{matcher}' but didn't.\nActual: '{actual}'",
+                matcher,
+                errorMessage);
         }
 
         /// <summary>
@@ -744,6 +734,20 @@ namespace RestAssured.Response
         private readonly record struct ResolvedBody(string Content, SupportedContentType ContentType);
 
         private readonly record struct NodePath(string Expression);
+
+        private VerifiableResponse VerifyResponseBody(Func<string, bool> failCondition, Func<string, string> buildDefaultMessage, object expectedValue, string? errorMessage)
+        {
+            string actual = this.ReadBodyAsString();
+
+            if (failCondition(actual))
+            {
+                this.FailVerification(errorMessage != null
+                    ? AssertionMessageBuilder.BuildMessage(errorMessage, expectedValue, actual)
+                    : buildDefaultMessage(actual));
+            }
+
+            return this;
+        }
 
         private string ReadBodyAsString()
         {

--- a/RestAssured.Net/Response/VerifiableResponse.cs
+++ b/RestAssured.Net/Response/VerifiableResponse.cs
@@ -590,7 +590,7 @@ namespace RestAssured.Response
             }
         }
 
-        private void VerifyJsonBody<T>(NodePath nodePath, IMatcher<T> matcher, ResolvedBody resolved, string? errorMessage = null)
+        private void VerifyJsonBody<T>(NodePath nodePath, IMatcher<T> matcher, ResolvedBody resolved, ErrorMessage errorMessage = default)
         {
             JToken? resultingElement = JToken.Parse(resolved.Content).SelectToken(nodePath.Expression);
 
@@ -605,13 +605,13 @@ namespace RestAssured.Response
 
             if (!matcher.Matches(valueToMatch))
             {
-                this.FailVerification(errorMessage != null
-                    ? AssertionMessageBuilder.BuildMessage(errorMessage, matcher, resultingElement!)
+                this.FailVerification(errorMessage.HasValue
+                    ? AssertionMessageBuilder.BuildMessage(errorMessage.Value!, matcher, resultingElement!)
                     : $"Expected element selected by '{nodePath.Expression}' to match '{matcher}' but was '{resultingElement}'");
             }
         }
 
-        private void VerifyJsonElements<T>(NodePath nodePath, IMatcher<IEnumerable<T>> matcher, ResolvedBody resolved, string? errorMessage = null)
+        private void VerifyJsonElements<T>(NodePath nodePath, IMatcher<IEnumerable<T>> matcher, ResolvedBody resolved, ErrorMessage errorMessage = default)
         {
             List<T> elementValues = new List<T>();
 
@@ -624,13 +624,13 @@ namespace RestAssured.Response
 
             if (!matcher.Matches(elementValues))
             {
-                this.FailVerification(errorMessage != null
-                    ? AssertionMessageBuilder.BuildMessage(errorMessage, matcher, string.Join(", ", elementValues))
+                this.FailVerification(errorMessage.HasValue
+                    ? AssertionMessageBuilder.BuildMessage(errorMessage.Value!, matcher, string.Join(", ", elementValues))
                     : $"Expected elements selected by '{nodePath.Expression}' to match '{matcher}', but was [{string.Join(", ", elementValues)}]");
             }
         }
 
-        private void VerifyMarkupBody<T>(NodePath nodePath, IMatcher<T> matcher, ResolvedBody resolved, string? errorMessage = null)
+        private void VerifyMarkupBody<T>(NodePath nodePath, IMatcher<T> matcher, ResolvedBody resolved, ErrorMessage errorMessage = default)
         {
             string innerText = this.SelectSingleNodeInnerText(nodePath, resolved);
 
@@ -639,8 +639,8 @@ namespace RestAssured.Response
             {
                 if (!matcher.Matches((T)Convert.ChangeType(innerText, typeof(T))))
                 {
-                    this.FailVerification(errorMessage != null
-                        ? AssertionMessageBuilder.BuildMessage(errorMessage, matcher, innerText)
+                    this.FailVerification(errorMessage.HasValue
+                        ? AssertionMessageBuilder.BuildMessage(errorMessage.Value!, matcher, innerText)
                         : $"Expected element selected by '{nodePath.Expression}' to match '{matcher}' but was '{innerText}'");
                 }
             }
@@ -650,7 +650,7 @@ namespace RestAssured.Response
             }
         }
 
-        private void VerifyMarkupElements<T>(NodePath nodePath, IMatcher<IEnumerable<T>> matcher, ResolvedBody resolved, string? errorMessage = null)
+        private void VerifyMarkupElements<T>(NodePath nodePath, IMatcher<IEnumerable<T>> matcher, ResolvedBody resolved, ErrorMessage errorMessage = default)
         {
             List<T> elementValues = new List<T>();
 
@@ -669,8 +669,8 @@ namespace RestAssured.Response
 
             if (!matcher.Matches(elementValues))
             {
-                this.FailVerification(errorMessage != null
-                    ? AssertionMessageBuilder.BuildMessage(errorMessage, matcher, string.Join(", ", elementValues))
+                this.FailVerification(errorMessage.HasValue
+                    ? AssertionMessageBuilder.BuildMessage(errorMessage.Value!, matcher, string.Join(", ", elementValues))
                     : $"Expected elements selected by '{nodePath.Expression}' to match '{matcher}', but was [{string.Join(", ", elementValues)}]");
             }
         }
@@ -735,14 +735,21 @@ namespace RestAssured.Response
 
         private readonly record struct NodePath(string Expression);
 
-        private VerifiableResponse VerifyResponseBody(Func<string, bool> failCondition, Func<string, string> buildDefaultMessage, object expectedValue, string? errorMessage)
+        private readonly record struct ErrorMessage(string? Value)
+        {
+            public bool HasValue => this.Value != null;
+
+            public static implicit operator ErrorMessage(string? value) => new ErrorMessage(value);
+        }
+
+        private VerifiableResponse VerifyResponseBody(Func<string, bool> failCondition, Func<string, string> buildDefaultMessage, object expectedValue, ErrorMessage errorMessage)
         {
             string actual = this.ReadBodyAsString();
 
             if (failCondition(actual))
             {
-                this.FailVerification(errorMessage != null
-                    ? AssertionMessageBuilder.BuildMessage(errorMessage, expectedValue, actual)
+                this.FailVerification(errorMessage.HasValue
+                    ? AssertionMessageBuilder.BuildMessage(errorMessage.Value!, expectedValue, actual)
                     : buildDefaultMessage(actual));
             }
 

--- a/RestAssured.Net/Response/VerifiableResponse.cs
+++ b/RestAssured.Net/Response/VerifiableResponse.cs
@@ -286,7 +286,7 @@ namespace RestAssured.Response
         /// <exception cref="ResponseVerificationException">Thrown when the actual response body does not match the expected one.</exception>
         public VerifiableResponse Body(string expectedResponseBody, string? errorMessage = null)
         {
-            string actualResponseBody = this.Response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            string actualResponseBody = this.ReadBodyAsString();
 
             if (!actualResponseBody.Equals(expectedResponseBody))
             {
@@ -307,7 +307,7 @@ namespace RestAssured.Response
         /// <exception cref="ResponseVerificationException">Thrown when the actual response body does not match the expected one.</exception>
         public VerifiableResponse Body(IMatcher<string> matcher, string? errorMessage = null)
         {
-            string actualResponseBody = this.Response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            string actualResponseBody = this.ReadBodyAsString();
 
             if (!matcher.Matches(actualResponseBody))
             {
@@ -744,6 +744,11 @@ namespace RestAssured.Response
         private readonly record struct ResolvedBody(string Content, SupportedContentType ContentType);
 
         private readonly record struct NodePath(string Expression);
+
+        private string ReadBodyAsString()
+        {
+            return this.Response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+        }
 
         private void FailVerification(string exceptionMessage)
         {


### PR DESCRIPTION
Closes #146.

All verification methods on `VerifiableResponse` (`StatusCode`, `Header`, `ContentType`, `Cookie`, `Body`, `ResponseTime`, `ResponseBodyLength`) now accept an optional `errorMessage` parameter. When supplied, that message is used in the `ResponseVerificationException` thrown on failure instead of (or prefixed to) the default diagnostic string.

## What changed

### New `ErrorMessage` value type (`RestAssured.Net/Response/ErrorMessage.cs`)

A lightweight `readonly struct` that wraps an optional `string`. Supports implicit conversion from `string?`, a `HasValue` guard, and Stubble template tokens `[expected]` and `[actual]` for injecting matcher and actual values into the message at runtime.

```csharp
.Then()
.StatusCode(200, errorMessage: "Login step should have returned 200")

.Body("$.user.name", Is.EqualTo("Alice"),
      errorMessage: "Expected [expected] but the API returned [actual]")
```

### `errorMessage` parameter on every assertion method

Every public verification method on `VerifiableResponse` gained an `ErrorMessage errorMessage = default` trailing parameter:

| Method | Overloads updated |
|--------|------------------|
| `StatusCode` | `int`, `HttpStatusCode`, `IMatcher<int>`, `IMatcher<HttpStatusCode>` |
| `Header` | `string value`, `IMatcher<string>` |
| `ContentType` | `string value`, `IMatcher<string>` |
| `Cookie` | `IMatcher<string>` |
| `Body` | `string`, `IMatcher<string>`, `IMatcher<T>`, `IMatcher<IEnumerable<T>>` |
| `ResponseTime` | `IMatcher<TimeSpan>` |
| `ResponseBodyLength` | `IMatcher<int>` |

### Message selection logic

| Scenario | Behaviour |
|----------|-----------|
| `errorMessage` not supplied | Existing detailed default message (no change) |
| `errorMessage` supplied — matcher mismatch | `AssertionMessageBuilder.BuildMessage` renders the template with `[expected]` → matcher, `[actual]` → actual value |
| `errorMessage` supplied — "not found" / null-result branches | `errorMessage` value alone (no template tokens available) |
| `errorMessage` supplied — no-results / type-conversion branches | `"{errorMessage}: {technical detail}"` so both the semantic context and the diagnostic detail are preserved |

### Internal refactoring

Two duplicate structural patterns were extracted into private helpers, resolving five CodeScene "Code Duplication" warnings:

- **`VerifyWithMatcher<T>`** — consolidates the `if (!matcher.Matches(value)) { FailVerification(…) }` pattern used by `StatusCode` (both overloads) and `ResponseTime`.
- **`DispatchBodyVerification`** — consolidates the `ResolveBodyAndContentType + NodePath + JSON/markup dispatch + return this` pattern shared by both generic `Body<T>` overloads.
